### PR TITLE
Prevent nested activation by default, but add `--replace` and `--stack` to opt in

### DIFF
--- a/conda_spawn/cli.py
+++ b/conda_spawn/cli.py
@@ -82,7 +82,11 @@ def execute(args: argparse.Namespace) -> int:
         raise ArgumentError(
             "--stack and --replace are mutually exclusive. Choose only one."
         )
-    if os.getenv("CONDA_SPAWN", "0") not in ("", "0") and not args.replace and not args.stack:
+    if (
+        os.getenv("CONDA_SPAWN", "0") not in ("", "0")
+        and not args.replace
+        and not args.stack
+    ):
         if current_env := os.getenv("CONDA_PREFIX"):
             env_info = f" for environment '{current_env}'"
         else:

--- a/conda_spawn/cli.py
+++ b/conda_spawn/cli.py
@@ -5,9 +5,10 @@ conda pip subcommand for CLI
 from __future__ import annotations
 
 import argparse
+import os
 from textwrap import dedent
 
-from conda.exceptions import ArgumentError
+from conda.exceptions import CondaError, ArgumentError
 from conda.cli.conda_argparse import (
     add_parser_help,
     add_parser_prefix,
@@ -42,10 +43,17 @@ def configure_parser(parser: argparse.ArgumentParser):
         help="Shell to use for the new session. If not specified, autodetect shell in use.",
     )
     shell_group.add_argument(
+        "--replace",
+        action="store_true",
+        help="Spawning shells within conda-spawn shells is disallowed by default. "
+        "This flag enables nested spawns by replacing the activated environment.",
+    )
+    shell_group.add_argument(
         "--stack",
         action="store_true",
-        help="Whether to stack the newly spawned environment."
-        "The default is to spawn a new session with replaced state.",
+        help="Spawning shells within conda-spawn shells is disallowed by default. "
+        "This flag enables nested spawns by stacking the newly activated environment "
+        "on top of the current one.",
     )
 
     parser.prog = "conda spawn"
@@ -69,6 +77,26 @@ def execute(args: argparse.Namespace) -> int:
         environment_speficier_to_path,
         shell_specifier_to_shell,
     )
+
+    if args.stack and args.replace:
+        raise ArgumentError(
+            "--stack and --replace are mutually exclusive. Choose only one."
+        )
+    if os.getenv("CONDA_SPAWN", "0") != "0" and not args.replace and not args.stack:
+        if current_env := os.getenv("CONDA_PREFIX"):
+            env_info = f" for environment '{current_env}'"
+        else:
+            env_info = ""
+        raise CondaError(
+            dedent(
+                f"""
+                Detected active 'conda spawn' session{env_info}.
+                Nested activation is disallowed by default.
+                Please exit the current session before starting a new one by running 'exit'.
+                Alternatively, check the usage of --replace and/or --stack.
+                """
+            ).lstrip()
+        )
 
     prefix = environment_speficier_to_path(args.name, args.prefix)
     shell = shell_specifier_to_shell(args.shell)

--- a/conda_spawn/cli.py
+++ b/conda_spawn/cli.py
@@ -41,6 +41,12 @@ def configure_parser(parser: argparse.ArgumentParser):
         choices=SHELLS,
         help="Shell to use for the new session. If not specified, autodetect shell in use.",
     )
+    shell_group.add_argument(
+        "--stack",
+        action="store_true",
+        help="Whether to stack the newly spawned environment."
+        "The default is to spawn a new session with replaced state.",
+    )
 
     parser.prog = "conda spawn"
     parser.epilog = dedent(
@@ -69,5 +75,5 @@ def execute(args: argparse.Namespace) -> int:
     if args.hook:
         if args.command:
             raise ArgumentError("COMMAND cannot be provided with --hook.")
-        return hook(prefix, shell)
-    return spawn(prefix, shell, command=args.command)
+        return hook(prefix, shell, stack=args.stack)
+    return spawn(prefix, shell, stack=args.stack, command=args.command)

--- a/conda_spawn/cli.py
+++ b/conda_spawn/cli.py
@@ -82,7 +82,7 @@ def execute(args: argparse.Namespace) -> int:
         raise ArgumentError(
             "--stack and --replace are mutually exclusive. Choose only one."
         )
-    if os.getenv("CONDA_SPAWN", "0") != "0" and not args.replace and not args.stack:
+    if os.getenv("CONDA_SPAWN", "0") not in ("", "0") and not args.replace and not args.stack:
         if current_env := os.getenv("CONDA_PREFIX"):
             env_info = f" for environment '{current_env}'"
         else:

--- a/conda_spawn/main.py
+++ b/conda_spawn/main.py
@@ -1,6 +1,7 @@
 """ """
 
 from __future__ import annotations
+
 from os.path import expanduser, expandvars, abspath
 from pathlib import Path
 from typing import Type, Iterable
@@ -24,7 +25,11 @@ def spawn(
     return shell_cls(prefix, stack=stack).spawn(command=command)
 
 
-def hook(prefix: Path, shell_cls: Shell | None = None, stack: bool = False) -> int:
+def hook(
+    prefix: Path,
+    shell_cls: Shell | None = None,
+    stack: bool = False,
+) -> int:
     if shell_cls is None:
         shell_cls = detect_shell_class()
     shell_inst = shell_cls(prefix, stack=stack)

--- a/conda_spawn/main.py
+++ b/conda_spawn/main.py
@@ -14,20 +14,22 @@ from .shell import SHELLS, Shell, detect_shell_class
 
 
 def spawn(
-    prefix: Path, shell_cls: Shell | None = None, command: Iterable[str] | None = None
+    prefix: Path,
+    shell_cls: Shell | None = None,
+    stack: bool = False,
+    command: Iterable[str] | None = None,
 ) -> int:
     if shell_cls is None:
         shell_cls = detect_shell_class()
-    return shell_cls(prefix).spawn(command=command)
+    return shell_cls(prefix, stack=stack).spawn(command=command)
 
 
-def hook(prefix: Path, shell_cls: Shell | None = None) -> int:
+def hook(prefix: Path, shell_cls: Shell | None = None, stack: bool = False) -> int:
     if shell_cls is None:
         shell_cls = detect_shell_class()
-    script = shell_cls(prefix).script()
-    prompt = shell_cls(prefix).prompt()
-    print(script)
-    print(prompt)
+    shell_inst = shell_cls(prefix, stack=stack)
+    print(shell_inst.script())
+    print(shell_inst.prompt())
     return 0
 
 

--- a/conda_spawn/shell.py
+++ b/conda_spawn/shell.py
@@ -28,10 +28,15 @@ log = getLogger(f"conda.{__name__}")
 class Shell:
     Activator: activate._Activator
 
-    def __init__(self, prefix: Path):
+    def __init__(self, prefix: Path, stack: bool = False):
         self.prefix = prefix
         self._prefix_str = str(prefix)
-        self._activator = self.Activator(["activate", str(self.prefix)])
+        self._stack = stack
+        self._activator_args = ["activate"]
+        if self._stack:
+            self._activator_args.append("--stack")
+        self._activator_args.append(str(prefix))
+        self._activator = self.Activator(self._activator_args)
         self._files_to_remove = []
 
     def spawn(self, prefix: Path) -> int:
@@ -50,9 +55,7 @@ class Shell:
         raise NotImplementedError
 
     def prompt_modifier(self) -> str:
-        conda_default_env = os.getenv(
-            "CONDA_DEFAULT_ENV", self._activator._default_env(self._prefix_str)
-        )
+        conda_default_env = self._activator._default_env(self._prefix_str)
         return self._activator._prompt_modifier(self._prefix_str, conda_default_env)
 
     def executable(self) -> str:

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -48,3 +48,12 @@ conda create -n new-env python numpy
 eval "$(conda spawn --hook --shell powershell -n new-env)"
 python -c "import numpy"
 ```
+
+## Nest activated environments
+
+Nested activation is disallowed by default. Instead we strongly recommend to only activate one environment at a time. Either open a new terminal session (window, tab, `screen`, `tmux`...) or close the current one with `exit` or <kbd>Ctrl</kbd>+<kbd>D</kbd>, and then run `conda spawn` again.
+
+That said, if you really want to reuse the current session, you can use one of these two nesting flags:
+
+- `--replace` will deactivate the current environment and activate the new one. Only the binaries in the new environment will be visible in `PATH`.
+- `--stack` will _not_ deactivate the current environment. Instead, it will activate the new one on top. Binaries in both environments will be visible in `PATH`, but the ones from the new environment will have precedence.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,31 @@
 import sys
 
+from conda import CondaError
+
 
 def test_cli(monkeypatch, conda_cli):
     monkeypatch.setattr(sys, "argv", ["conda", *sys.argv[1:]])
     out, err, _ = conda_cli("spawn", "-h", raises=SystemExit)
     assert not err
     assert "conda spawn" in out
+
+
+def test_nesting_disallowed(monkeypatch, conda_cli):
+    monkeypatch.setenv("CONDA_SPAWN", "1")
+    conda_cli("spawn", "-p", sys.prefix, "--hook", raises=CondaError)
+
+
+def test_nesting_replace(monkeypatch, conda_cli):
+    monkeypatch.setenv("CONDA_SPAWN", "1")
+    out, err, rc = conda_cli("spawn", "-p", sys.prefix, "--hook", "--replace")
+    assert sys.prefix in out
+    assert not err
+    assert not rc
+
+
+def test_nesting_stack(monkeypatch, conda_cli):
+    monkeypatch.setenv("CONDA_SPAWN", "1")
+    out, err, rc = conda_cli("spawn", "-p", sys.prefix, "--hook", "--stack")
+    assert sys.prefix in out
+    assert not err
+    assert not rc

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -8,7 +8,6 @@ from conda.base.context import reset_context
 from conda_spawn.shell import PosixShell, PowershellShell, CmdExeShell
 
 
-
 @pytest.fixture(scope="session")
 def simple_env(session_tmp_env):
     with session_tmp_env() as prefix:

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,9 +1,12 @@
 import sys
 
 import pytest
+from subprocess import PIPE, check_output
+
+from conda.base.context import reset_context
+
 from conda_spawn.shell import PosixShell, PowershellShell, CmdExeShell
 
-from subprocess import PIPE, check_output
 
 
 @pytest.fixture(scope="session")
@@ -16,6 +19,13 @@ def simple_env(session_tmp_env):
 def conda_env(session_tmp_env):
     with session_tmp_env("conda") as prefix:
         yield prefix
+
+
+@pytest.fixture
+def no_prompt(monkeypatch):
+    monkeypatch.setenv("CONDA_CHANGEPS1", "false")
+    reset_context()
+    yield
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Pty's only available on Unix")
@@ -101,12 +111,13 @@ def test_hooks_integration_cmd(simple_env, tmp_path):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Pty's only available on Unix")
-def test_condabin_first_posix_shell(simple_env, conda_env):
+def test_condabin_first_posix_shell(simple_env, conda_env, no_prompt):
     shell = PosixShell(simple_env)
     proc = shell.spawn_tty()
     proc.sendline('echo "$PATH"')
     proc.sendeof()
     out = proc.read().decode()
+    print(out)
     assert sys.prefix in out
     assert str(simple_env) in out
     assert out.index(sys.prefix) < out.index(str(simple_env))
@@ -115,13 +126,14 @@ def test_condabin_first_posix_shell(simple_env, conda_env):
     proc = shell.spawn_tty()
     proc.sendline("which conda")
     proc.sendeof()
+    print(out)
     out = proc.read().decode()
     assert f"{sys.prefix}/condabin/conda" in out
     assert str(conda_env) not in out
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Powershell only tested on Windows")
-def test_condabin_first_powershell(simple_env, conda_env):
+def test_condabin_first_powershell(simple_env, conda_env, no_prompt):
     shell = PowershellShell(simple_env)
     with shell.spawn_popen(
         command=["echo", "$env:PATH"], stdout=PIPE, text=True
@@ -144,7 +156,7 @@ def test_condabin_first_powershell(simple_env, conda_env):
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Cmd.exe only tested on Windows")
-def test_condabin_first_cmd(simple_env, conda_env):
+def test_condabin_first_cmd(simple_env, conda_env, no_prompt):
     shell = CmdExeShell(simple_env)
     with shell.spawn_popen(command=["echo", "%PATH%"], stdout=PIPE, text=True) as proc:
         out, _ = proc.communicate(timeout=5)


### PR DESCRIPTION
If a user `spawn`s two nested environments, current behaviour mimics `activate`, which replaces entries in PATH instead of inserting them ahead. I'm not sure what the expectation is, probably nesting/stacking by default? I don't think this is a good idea for UX, as with this project we are trying to prevent as many footguns as possible.

In this Zulip thread, several options were debated (allow nesting with replacement or stacking by default, or not allow it unless a specific flag is given). In the end I've decided for this design:

- Nested activation is disallowed by default.
- If you really want to nest, then you must pick a method:
  - `--replace`: will nest and _replace_ the current environment
  - `--stack`: will nest and _stack_ on top of the previously activated environment.

Let's say you already executed `conda spawn -n base` and now want to work on a different environment named `project`.

- The naive `conda spawn -n project` will error out telling you to exit first or use a nesting flag.
- If you do `conda spawn -n project --replace`, the binaries in `project` will be in PATH, but not those in `base`.
- With `conda spawn -n project --stack`, the binaries of both `project` and `base` will be visible, but `project` will always take precedence. 