### PR TITLE
Add support for the (prefix) shell

### DIFF
--- a/conda_spawn/activate.py
+++ b/conda_spawn/activate.py
@@ -830,9 +830,9 @@ def backslash_to_forwardslash(
 
 
 class PosixActivator(_Activator):
-    pathsep_join = ";".join if on_win else ":".join
+    pathsep_join = ":".join
     sep = "/"
-    path_conversion = staticmethod(win_path_to_unix if False else _path_identity)
+    path_conversion = staticmethod(win_path_to_unix if on_win else _path_identity)
     script_extension = ".sh"
     tempfile_extension = None  # output to stdout
     command_join = "\n"
@@ -840,7 +840,7 @@ class PosixActivator(_Activator):
     unset_var_tmpl = "unset %s"
     export_var_tmpl = "export %s='%s'"
     set_var_tmpl = "%s='%s'"
-    run_script_tmpl = 'source "%s"'
+    run_script_tmpl = '. "%s"'
 
     hook_source_path = Path(
         CONDA_PACKAGE_ROOT,
@@ -1077,6 +1077,11 @@ class PowerShellActivator(_Activator):
         return "Remove-Variable CondaModuleArgs"
 
 
+class ShellActivator(PosixActivator):
+    pathsep_join = ";".join if on_win else ":".join
+    path_conversion = staticmethod(_path_identity)
+    run_script_tmpl = 'source "%s"'
+
 activator_map: dict[str, type[_Activator]] = {
     "posix": PosixActivator,
     "ash": PosixActivator,
@@ -1089,4 +1094,5 @@ activator_map: dict[str, type[_Activator]] = {
     "cmd.exe": CmdExeActivator,
     "fish": FishActivator,
     "powershell": PowerShellActivator,
+    "shell": ShellActivator,
 }

--- a/conda_spawn/activate.py
+++ b/conda_spawn/activate.py
@@ -830,9 +830,9 @@ def backslash_to_forwardslash(
 
 
 class PosixActivator(_Activator):
-    pathsep_join = ":".join
+    pathsep_join = ";".join if on_win else ":".join
     sep = "/"
-    path_conversion = staticmethod(win_path_to_unix if on_win else _path_identity)
+    path_conversion = staticmethod(win_path_to_unix if False else _path_identity)
     script_extension = ".sh"
     tempfile_extension = None  # output to stdout
     command_join = "\n"

--- a/conda_spawn/activate.py
+++ b/conda_spawn/activate.py
@@ -840,7 +840,7 @@ class PosixActivator(_Activator):
     unset_var_tmpl = "unset %s"
     export_var_tmpl = "export %s='%s'"
     set_var_tmpl = "%s='%s'"
-    run_script_tmpl = '. "%s"'
+    run_script_tmpl = 'source "%s"'
 
     hook_source_path = Path(
         CONDA_PACKAGE_ROOT,

--- a/conda_spawn/activate.py
+++ b/conda_spawn/activate.py
@@ -1082,6 +1082,7 @@ class ShellActivator(PosixActivator):
     path_conversion = staticmethod(_path_identity)
     run_script_tmpl = 'source "%s"'
 
+
 activator_map: dict[str, type[_Activator]] = {
     "posix": PosixActivator,
     "ash": PosixActivator,

--- a/conda_spawn/shell.py
+++ b/conda_spawn/shell.py
@@ -163,6 +163,7 @@ class ZshShell(PosixShell):
     def executable(self):
         return "zsh"
 
+
 class ShellShell(PosixShell):
     def executable(self):
         return "shell"

--- a/conda_spawn/shell.py
+++ b/conda_spawn/shell.py
@@ -308,6 +308,8 @@ def default_shell_class():
 def detect_shell_class():
     try:
         name, _ = shellingham.detect_shell()
+        if sys.platform == "win32" and name == "cmd" and "SHELL" in os.environ:
+            name = os.environ["SHELL"]
     except shellingham.ShellDetectionFailure:
         return default_shell_class()
     else:

--- a/conda_spawn/shell.py
+++ b/conda_spawn/shell.py
@@ -140,7 +140,7 @@ class PosixShell(Shell):
             # We set the PS1 prompt outside the script because it's otherwise invisible.
             # stty echo is equivalent to `child.setecho(True)` but the latter didn't work
             # reliably across all shells and OSs.
-            child.sendline(f' source "{f.name}" && {self.prompt()} && stty echo')
+            child.sendline(f' . "{f.name}" && {self.prompt()} && stty echo')
             os.read(child.child_fd, 4096)  # consume buffer before interact
             if Path(executable).name == "zsh":
                 # zsh also needs this for a truly silent activation
@@ -165,6 +165,8 @@ class ZshShell(PosixShell):
 
 
 class ShellShell(PosixShell):
+    Activator = activate.ShellActivator
+
     def executable(self):
         return "shell"
 

--- a/conda_spawn/shell.py
+++ b/conda_spawn/shell.py
@@ -184,6 +184,7 @@ class ShellShell(PosixShell):
                 mode="w",
             ) as f:
                 f.write(self.script())
+                f.write(f"{self.prompt()}\n")
                 if command:
                     f.write(" ".join(command))
             return subprocess.Popen(

--- a/conda_spawn/shell.py
+++ b/conda_spawn/shell.py
@@ -184,6 +184,8 @@ class ShellShell(PosixShell):
                 mode="w",
             ) as f:
                 f.write(self.script())
+                if command:
+                    f.write(" ".join(command))
             return subprocess.Popen(
                 [self.executable(), *self.args(), f.name], env=self.env(), **kwargs
             )

--- a/conda_spawn/shell.py
+++ b/conda_spawn/shell.py
@@ -311,8 +311,6 @@ def default_shell_class():
 def detect_shell_class():
     try:
         name, _ = shellingham.detect_shell()
-        if sys.platform == "win32" and name == "cmd" and "SHELL" in os.environ:
-            name = os.environ["SHELL"]
     except shellingham.ShellDetectionFailure:
         return default_shell_class()
     else:

--- a/conda_spawn/shell.py
+++ b/conda_spawn/shell.py
@@ -163,6 +163,10 @@ class ZshShell(PosixShell):
     def executable(self):
         return "zsh"
 
+class ShellShell(PosixShell):
+    def executable(self):
+        return "shell"
+
 
 class CshShell(Shell):
     pass
@@ -260,6 +264,7 @@ SHELLS: dict[str, type[Shell]] = {
     "posix": PosixShell,
     "powershell": PowershellShell,
     "pwsh": PowershellShell,
+    "shell": ShellShell,
     "tcsh": CshShell,
     "xonsh": XonshShell,
     "zsh": ZshShell,

--- a/conda_spawn/shell.py
+++ b/conda_spawn/shell.py
@@ -140,7 +140,7 @@ class PosixShell(Shell):
             # We set the PS1 prompt outside the script because it's otherwise invisible.
             # stty echo is equivalent to `child.setecho(True)` but the latter didn't work
             # reliably across all shells and OSs.
-            child.sendline(f' . "{f.name}" && {self.prompt()} && stty echo')
+            child.sendline(f' source "{f.name}" && {self.prompt()} && stty echo')
             os.read(child.child_fd, 4096)  # consume buffer before interact
             if Path(executable).name == "zsh":
                 # zsh also needs this for a truly silent activation
@@ -166,6 +166,9 @@ class ZshShell(PosixShell):
 class ShellShell(PosixShell):
     def executable(self):
         return "shell"
+
+    def args(self):
+        return ()
 
 
 class CshShell(Shell):


### PR DESCRIPTION
It's not working yet, but almost:
```console
(spawn2) conda-spawn/conda_spawn(shell)$ $CONDA_PREFIX/bin/conda spawn  -n t1 --shell shell
~/repos/conda-spawn/conda_spawn$  source "/var/folders/vg/lymvsp1153sgwwfdh3pm45
hw0000gn/T/conda-spawn-c14_qd7s.sh" && PS1="(t1) ${PS1:-}" && stty echo
.: command not found
~/repos/conda-spawn/conda_spawn$ 
```
It launches `shell`, but doesn't load the environment correctly yet. I think `shell` doesn't support `.` yet (https://github.com/prefix-dev/shell/issues/203), only `source`.

The activation script contains:
```
. "/Users/ondrej/miniforge3/envs/spawn2/etc/conda/deactivate.d/libxml2_deactivate.sh"
unset CONDA_EXE
unset _CE_M
unset _CE_CONDA
unset CONDA_PYTHON_EXE
export PATH='/Users/ondrej/miniforge3/envs/spawn2/envs/t1/bin:/Users/ondrej/miniforge3/condabin:/Users/ondrej/.pixi/bin:/Users/ondrej/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Users/ondrej/.cargo/bin:/Users/ondrej/.cache/lm-studio/bin'
export CONDA_PREFIX='/Users/ondrej/miniforge3/envs/spawn2/envs/t1'
export CONDA_SHLVL='2'
export CONDA_DEFAULT_ENV='t1'
export CONDA_PROMPT_MODIFIER='(t1) '
export CONDA_PREFIX_1='/Users/ondrej/miniforge3/envs/spawn2'
```
I think this is coming from `conda` itself, so it fails.