### PR TITLE
Fix double prompt when spawning a shell

### DIFF
--- a/conda_spawn/shell.py
+++ b/conda_spawn/shell.py
@@ -139,15 +139,17 @@ class PosixShell(Shell):
                 mode="w",
             ) as f:
                 f.write(self.script())
+                # Append prompt setup, echo restore, and the ready marker
+                # to the *same* sourced file so the only thing we sendline
+                # is `. "<path>"`.  If the PTY's input echo is on when the
+                # sendline lands (e.g. zsh rc files / starship init flipped
+                # it back on), the echoed command no longer contains the
+                # marker text -- so it cannot leak through to interact().
+                f.write(f"\n{self.prompt()}\n")
+                f.write("stty echo\n")
+                f.write(f"printf {self._READY_MARKER}\n")
             signal.signal(signal.SIGWINCH, _sigwinch_passthrough)
-            # Source the activation script, set the prompt, re-enable echo,
-            # then print a ready marker. Using printf (no trailing newline)
-            # lets expect_exact consume everything up to and including the
-            # marker without leaving stray characters in the buffer.
-            child.sendline(
-                f' . "{f.name}" && {self.prompt()} && stty echo'
-                f" && printf {self._READY_MARKER}"
-            )
+            child.sendline(f' . "{f.name}"')
             child.expect_exact(self._READY_MARKER)
             if command:
                 child.sendline(shlex.join(command))

--- a/conda_spawn/shell.py
+++ b/conda_spawn/shell.py
@@ -107,7 +107,7 @@ class PosixShell(Shell):
     # Sentinel printed after activation to reliably detect when the
     # spawned shell is ready.  Everything before this marker (including
     # any initial prompt rendered with stale env vars) is consumed
-    # before ``interact()`` starts, preventing a duplicate prompt.
+    # before `interact()` starts, preventing a duplicate prompt.
     _READY_MARKER = "__CONDA_SPAWN_READY__"
 
     def spawn_tty(self, command: Iterable[str] | None = None) -> pexpect.spawn:
@@ -141,7 +141,7 @@ class PosixShell(Shell):
                 f.write(self.script())
             signal.signal(signal.SIGWINCH, _sigwinch_passthrough)
             # Source the activation script, set the prompt, re-enable echo,
-            # then print a ready marker.  Using printf (no trailing newline)
+            # then print a ready marker. Using printf (no trailing newline)
             # lets expect_exact consume everything up to and including the
             # marker without leaving stray characters in the buffer.
             child.sendline(

--- a/conda_spawn/shell.py
+++ b/conda_spawn/shell.py
@@ -104,6 +104,12 @@ class PosixShell(Shell):
     def args(self):
         return self.default_args
 
+    # Sentinel printed after activation to reliably detect when the
+    # spawned shell is ready.  Everything before this marker (including
+    # any initial prompt rendered with stale env vars) is consumed
+    # before ``interact()`` starts, preventing a duplicate prompt.
+    _READY_MARKER = "__CONDA_SPAWN_READY__"
+
     def spawn_tty(self, command: Iterable[str] | None = None) -> pexpect.spawn:
         def _sigwinch_passthrough(sig, data):
             # NOTE: Taken verbatim from pexpect's .interact() docstring.
@@ -117,7 +123,6 @@ class PosixShell(Shell):
             child.setwinsize(a[0], a[1])
 
         size = shutil.get_terminal_size()
-        executable = self.executable()
 
         child = pexpect.spawn(
             self.executable(),
@@ -135,16 +140,15 @@ class PosixShell(Shell):
             ) as f:
                 f.write(self.script())
             signal.signal(signal.SIGWINCH, _sigwinch_passthrough)
-            # Source the activation script. We do this in a single line for performance.
-            # (It's slower to send several lines than paying the IO overhead).
-            # We set the PS1 prompt outside the script because it's otherwise invisible.
-            # stty echo is equivalent to `child.setecho(True)` but the latter didn't work
-            # reliably across all shells and OSs.
-            child.sendline(f' . "{f.name}" && {self.prompt()} && stty echo')
-            os.read(child.child_fd, 4096)  # consume buffer before interact
-            if Path(executable).name == "zsh":
-                # zsh also needs this for a truly silent activation
-                child.expect("\r\n")
+            # Source the activation script, set the prompt, re-enable echo,
+            # then print a ready marker.  Using printf (no trailing newline)
+            # lets expect_exact consume everything up to and including the
+            # marker without leaving stray characters in the buffer.
+            child.sendline(
+                f' . "{f.name}" && {self.prompt()} && stty echo'
+                f" && printf {self._READY_MARKER}"
+            )
+            child.expect_exact(self._READY_MARKER)
             if command:
                 child.sendline(shlex.join(command))
             if sys.stdin.isatty():

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -40,7 +40,7 @@ def test_posix_shell(simple_env):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Pty's only available on Unix")
-def test_posix_shell_ready_marker_synchronization(simple_env):
+def test_posix_shell_ready_marker_synchronization(simple_env, request):
     """Regression test for the double-prompt fix (#22).
 
     ``spawn_tty()`` prints a distinctive ready marker after the activation
@@ -57,16 +57,19 @@ def test_posix_shell_ready_marker_synchronization(simple_env):
     """
     shell = PosixShell(simple_env)
     proc = shell.spawn_tty()
-    try:
-        marker = PosixShell._READY_MARKER
-        assert marker, "PosixShell must define a non-empty _READY_MARKER"
-        # expect_exact() leaves the matched literal in child.after; if
-        # someone removes the marker sync this assertion fails loudly
-        # instead of regressing to the old racy os.read()-based approach.
-        assert proc.after == marker.encode()
-    finally:
+
+    def _drain():
         proc.sendeof()
         proc.read()
+
+    request.addfinalizer(_drain)
+
+    marker = PosixShell._READY_MARKER
+    assert marker, "PosixShell must define a non-empty _READY_MARKER"
+    # expect_exact() leaves the matched literal in child.after; if
+    # someone removes the marker sync this assertion fails loudly
+    # instead of regressing to the old racy os.read()-based approach.
+    assert proc.after == marker.encode()
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Powershell only tested on Windows")

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -39,6 +39,36 @@ def test_posix_shell(simple_env):
     assert str(simple_env) in out
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Pty's only available on Unix")
+def test_posix_shell_ready_marker_synchronization(simple_env):
+    """Regression test for the double-prompt fix (#22).
+
+    ``spawn_tty()`` prints a distinctive ready marker after the activation
+    script, the new ``PS1``, and ``stty echo`` have all been applied, and
+    then blocks on ``expect_exact`` until it sees that marker.  Because
+    ``expect_exact`` consumes everything up to *and including* the match,
+    any output the shell emitted before activation completed -- including
+    an initial prompt rendered from the parent process's (stale)
+    ``CONDA_DEFAULT_ENV``, which is what prompt tools like starship would
+    read -- ends up in ``child.before`` and is never forwarded to the
+    interactive user.
+
+    Refs conda-incubator/conda-workspaces#20.
+    """
+    shell = PosixShell(simple_env)
+    proc = shell.spawn_tty()
+    try:
+        marker = PosixShell._READY_MARKER
+        assert marker, "PosixShell must define a non-empty _READY_MARKER"
+        # expect_exact() leaves the matched literal in child.after; if
+        # someone removes the marker sync this assertion fails loudly
+        # instead of regressing to the old racy os.read()-based approach.
+        assert proc.after == marker.encode()
+    finally:
+        proc.sendeof()
+        proc.read()
+
+
 @pytest.mark.skipif(sys.platform != "win32", reason="Powershell only tested on Windows")
 def test_powershell(simple_env):
     shell = PowershellShell(simple_env)


### PR DESCRIPTION
When a shell is spawned via `conda spawn` (or `conda workspace shell`), prompt tools like starship read `CONDA_DEFAULT_ENV` from the inherited environment and render an initial prompt showing the parent env (e.g. `base`). The activation script then updates the variable and the shell renders a second prompt with the correct env name, producing the double-prompt artifact reported in conda-incubator/conda-workspaces#20.

The old approach used `os.read(child.child_fd, 4096)` plus a zsh-specific `child.expect("\r\n")` to consume the initial output before `interact()`. This was racy — if the prompt rendered slowly (starship, powerline, etc.) the read would return before it was fully written.

This replaces that with a ready marker (`__CONDA_SPAWN_READY__`) printed via `printf` (no trailing newline) after activation + prompt setup + `stty echo` all complete. `expect_exact` blocks until the marker appears, so everything before it — including any stale initial prompt — is consumed. The zsh special case is no longer needed.

Refs conda-incubator/conda-workspaces#20