### PR TITLE
Keep `$CONDA_ROOT/condabin` first when replacing a prefix in `PATH`

### DIFF
--- a/conda_spawn/activate.py
+++ b/conda_spawn/activate.py
@@ -696,6 +696,11 @@ class _Activator(metaclass=abc.ABCMeta):
         if new_prefix is not None:
             path_list[first_idx:first_idx] = list(self._get_path_dirs(new_prefix))
 
+        # JRG: Mirror _add_prefix_to_path: keep $CONDA_ROOT/condabin at position 0
+        # so the base `conda` executable is never shadowed when swapping/removing
+        # prefixes (e.g. activate from CONDA_SHLVL>0, deactivate, reactivate).
+        self._ensure_root_condabin_is_first(path_list)
+
         return tuple(path_list)
 
     def _update_prompt(self, set_vars, conda_prompt_modifier):


### PR DESCRIPTION
## Summary

`_ensure_root_condabin_is_first()` was only called from `_add_prefix_to_path()`. `_build_activate_stack()` goes through `_add_prefix_to_path()` only when `old_conda_shlvl == 0` or when stacking. When activating over an already active environment (`old_conda_shlvl > 0 and stack=False`), it goes through `_replace_prefix_in_path()` instead, which did not enforce condabin-first. `build_deactivate()` and `build_reactivate()` also use `_replace_prefix_in_path()` / `_remove_prefix_from_path()` and had the same gap.

Pixi sets `CONDA_SHLVL=1` / `CONDA_PREFIX` / `CONDA_DEFAULT_ENV` during `pixi run`, so any `conda spawn activate` inside that context took the replace branch and dropped `<conda_root>/condabin` from `PATH`. This is why `tests/test_shell.py::test_condabin_first_posix_shell` started failing on CI with no conda-spawn code change — pixi behavior changed, the test didn't.

The fix calls `_ensure_root_condabin_is_first()` at the end of `_replace_prefix_in_path()`, mirroring the existing call at the end of `_add_prefix_to_path()`. The invariant now holds across all three entry points: activate, reactivate, deactivate.

Tracking issue: #24. Draft until CI confirms the fix across the matrix.

## Test plan

- [x] Reproduced failure locally on `main` inside `pixi run -e test-py312 test tests/test_shell.py::test_condabin_first_posix_shell` (fails on `assert sys.prefix in out`).
- [x] With the fix applied, the PATH assertions (`sys.prefix in out`, `simple_env in out`, `out.index(sys.prefix) < out.index(simple_env)`) pass locally.
- [x] CI across the full matrix (linux-64, osx, win).
- [ ] Optional follow-up: check if `which conda`/`command -v conda` assertion needs a similar fix or test-env cleanup.

## Repro

```shell
$ pixi run -e test-py312 sh -c 'env | grep CONDA_'
CONDA_SHLVL=1
CONDA_PREFIX=/.../.pixi/envs/test-py312
CONDA_DEFAULT_ENV=conda-spawn:test-py312
```

With `CONDA_SHLVL=1` the generated script on `main` exports `PATH='<simple_env>/bin:<rest>'` (no condabin). With this PR it exports `PATH='<conda_root>/condabin:<simple_env>/bin:<rest>'`.