### PR TITLE
Add fish, csh/tcsh, and xonsh shell support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,20 +25,15 @@ concurrency:
 
 jobs:
   tests:
-    name: ${{ matrix.os }}, py${{ matrix.python-version }}, ${{ matrix.channel }}
+    name: ${{ matrix.os }}, py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        channel: [defaults, conda-forge]
         python-version: ["310", "311", "312", "313", "314"]
         include:
           - os: macos-latest
-            channel: defaults
-            python-version: "312"
-          - os: macos-latest
-            channel: conda-forge
             python-version: "314"
     env:
       PIXI_ENV_NAME: test-py${{ matrix.python-version }}
@@ -46,27 +41,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - name: Patch channels in pixi config
-        if: matrix.channel == 'defaults'
-        shell: bash
-        run: |
-          # Swap pixi's own channels to the Anaconda defaults repos.
-          sed -i.bak 's|channels = \["conda-forge"\]|channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/r", "https://repo.anaconda.com/pkgs/msys2"]|g' pyproject.toml
-          # Python 3.14 isn't on Anaconda defaults for osx-64 (Intel Mac) yet,
-          # so drop that platform from the workspace on defaults rows only.
-          # conda-forge rows keep the full four-platform set, including osx-64.
-          sed -i.bak 's|platforms = \["linux-64", "osx-64", "osx-arm64", "win-64"\]|platforms = ["linux-64", "osx-arm64", "win-64"]|' pyproject.toml
-          # Drop the conda-forge-resolved lockfile so setup-pixi regenerates it.
-          rm pixi.lock
       - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           environments: ${{ env.PIXI_ENV_NAME }}
       - name: Setup project
         shell: bash
         run: |
-          # Point the conda executable inside the pixi env at the same channel
-          # we're testing against.
-          echo "channels: [${{ matrix.channel }}]" > .pixi/envs/${{ env.PIXI_ENV_NAME }}/.condarc
+          echo "channels: [conda-forge]" > .pixi/envs/${{ env.PIXI_ENV_NAME }}/.condarc
           pixi run --environment ${{ env.PIXI_ENV_NAME }} conda info
       - name: Run tests
         run: pixi run --environment ${{ env.PIXI_ENV_NAME }} test --basetemp=${{ runner.os == 'Windows' && 'D:\\temp' || runner.temp }}

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ conda install -n base conda-forge::conda-spawn
 
 More information is available on our [documentation](https://conda-incubator.github.io/conda-spawn).
 
+## Supported shells
+
+`conda-spawn` distinguishes two tiers of shell support:
+
+- **Fully supported**: `bash`, `zsh`, `powershell`, `cmd`. Covered by CI on every push and actively maintained.
+- **Best-effort**: `fish`, `csh`/`tcsh`, `xonsh`. Provided to match `conda activate`'s own activator coverage so `conda-spawn` can replace it on systems that use those shells. They are lightly tested and we rely on user reports to catch shell-specific bugs.
+
 ## Contributing
 
 Please refer to [`CONTRIBUTING.md`](/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ More information is available on our [documentation](https://conda-incubator.git
 
 `conda-spawn` distinguishes two tiers of shell support:
 
-- **Fully supported**: `bash`, `zsh`, `powershell`, `cmd`. Covered by CI on every push and actively maintained.
-- **Best-effort**: `fish`, `csh`/`tcsh`, `xonsh`. Provided to match `conda activate`'s own activator coverage so `conda-spawn` can replace it on systems that use those shells. They are lightly tested and we rely on user reports to catch shell-specific bugs.
+- **Fully supported**: `bash`, `zsh`, `powershell`, `cmd`. Implemented in `conda_spawn.shell`. Covered by CI on every push and actively maintained.
+- **Best-effort**: `fish`, `csh`/`tcsh`, `xonsh`. Implemented in `conda_spawn.contrib`. Provided to match `conda activate`'s own activator coverage so `conda-spawn` can replace it on systems that use those shells. They are lightly tested and we rely on user reports to catch shell-specific bugs.
 
 ## Contributing
 

--- a/conda_spawn/__init__.py
+++ b/conda_spawn/__init__.py
@@ -1,5 +1,5 @@
 """
-conda go: activate conda environments in new shell processes.
+conda spawn: activate conda environments in new shell processes.
 """
 
 from .main import spawn, hook  # noqa

--- a/conda_spawn/cli.py
+++ b/conda_spawn/cli.py
@@ -1,5 +1,5 @@
 """
-conda pip subcommand for CLI
+conda spawn subcommand for CLI.
 """
 
 from __future__ import annotations

--- a/conda_spawn/cli.py
+++ b/conda_spawn/cli.py
@@ -16,7 +16,7 @@ from conda.cli.conda_argparse import (
 
 
 def configure_parser(parser: argparse.ArgumentParser):
-    from .shell import SHELLS
+    from .registry import SHELLS
 
     add_parser_help(parser)
 

--- a/conda_spawn/contrib.py
+++ b/conda_spawn/contrib.py
@@ -1,0 +1,151 @@
+"""Best-effort shell support for conda-spawn.
+
+These shells are provided to bring `conda spawn` to parity with
+`conda activate`'s own activator coverage so it can replace
+`conda activate` on systems that use them.  They are lightly tested
+relative to the core supported matrix (`bash`, `zsh`, `powershell`,
+`cmd`) and rely on user reports for shell-specific bugs.
+"""
+
+from __future__ import annotations
+
+import re
+
+from . import activate
+from .shell import UnixShell
+
+
+class FishShell(UnixShell):
+    """fish shell support.
+
+    Best-effort: not part of the core supported shell matrix (`bash`,
+    `zsh`, `powershell`, `cmd`). It exists to bring `conda spawn` to
+    parity with `conda activate`'s own activator coverage, but is
+    lightly tested and relies on user reports for shell-specific bugs.
+    """
+
+    Activator = activate.FishActivator
+    default_shell = "fish"
+
+    def prompt(self) -> str:
+        # Preserve any pre-existing `fish_prompt` (including ones installed
+        # by prompt tools like starship) and prepend conda's prompt modifier
+        # so users see their env name regardless of their shell setup.
+        return (
+            "if functions -q fish_prompt\n"
+            "    if not functions -q __conda_spawn_orig_fish_prompt\n"
+            "        functions -c fish_prompt __conda_spawn_orig_fish_prompt\n"
+            "        functions -e fish_prompt\n"
+            "    end\n"
+            "end\n"
+            "function fish_prompt\n"
+            '    printf "%s" "$CONDA_PROMPT_MODIFIER"\n'
+            "    if functions -q __conda_spawn_orig_fish_prompt\n"
+            "        __conda_spawn_orig_fish_prompt\n"
+            "    end\n"
+            "end"
+        )
+
+    def source_command(self, script_path: str) -> str:
+        return f'source "{script_path}"'
+
+    def executable(self) -> str:
+        return "fish"
+
+
+class CshShell(UnixShell):
+    """csh shell support.
+
+    Best-effort: not part of the core supported shell matrix (`bash`,
+    `zsh`, `powershell`, `cmd`). It exists to bring `conda spawn` to
+    parity with `conda activate`'s own activator coverage, but is
+    lightly tested and relies on user reports for shell-specific bugs.
+    """
+
+    Activator = activate.CshActivator
+    default_shell = "csh"
+    default_args = ("-i",)
+    prompt_strip_markers = ("set prompt=",)
+
+    def prompt(self) -> str:
+        # csh/tcsh do not define $prompt automatically in all modes; guard
+        # against "Undefined variable" by initialising it to "" if absent.
+        return (
+            'if (! $?prompt) set prompt = ""\n'
+            f'set prompt="{self.prompt_modifier()}${{prompt}}"'
+        )
+
+    def source_command(self, script_path: str) -> str:
+        return f'source "{script_path}"'
+
+    def ready_marker_command(self) -> str:
+        # csh does not ship a `printf` builtin; `echo -n` is portable
+        # across csh/tcsh on the platforms we support.
+        return f'echo -n "{self.READY_MARKER}"'
+
+    def executable(self) -> str:
+        return "csh"
+
+
+class TcshShell(CshShell):
+    """tcsh shell support.
+
+    Inherits the same best-effort caveat as `CshShell`.
+    """
+
+    default_shell = "tcsh"
+
+    def executable(self) -> str:
+        return "tcsh"
+
+
+class XonshShell(UnixShell):
+    """xonsh shell support.
+
+    Best-effort: not part of the core supported shell matrix (`bash`,
+    `zsh`, `powershell`, `cmd`). It exists to bring `conda spawn` to
+    parity with `conda activate`'s own activator coverage, but is
+    lightly tested and relies on user reports for shell-specific bugs.
+    """
+
+    Activator = activate.XonshActivator
+    default_shell = "xonsh"
+    default_args = ("-i",)
+
+    @property
+    def script_suffix(self) -> str:
+        # The `XonshActivator` reports `.sh` (for bash-sourced
+        # `activate.d` scripts) but `execute()` emits xonsh syntax.
+        # `.xsh` is the canonical extension for xonsh scripts.
+        return ".xsh"
+
+    def script(self) -> str:
+        # `XonshActivator.unset_var_tmpl` emits `del $VAR` which raises
+        # `KeyError` when the variable is not already set (e.g. on a fresh
+        # CI runner).  Replace every such line with the safe pop form.
+        raw = super().script()
+        return re.sub(
+            r"^del \$(\w+)$",
+            lambda m: f'${{...}}.pop("{m.group(1)}", None)',
+            raw,
+            flags=re.MULTILINE,
+        )
+
+    def prompt(self) -> str:
+        # Prepend `CONDA_PROMPT_MODIFIER` to `$PROMPT` while keeping
+        # any format-field tokens in the user's prompt intact.
+        return "$PROMPT = ${...}.get('CONDA_PROMPT_MODIFIER', '') + $PROMPT"
+
+    def source_command(self, script_path: str) -> str:
+        return f'source "{script_path}"'
+
+    def post_activation_command(self) -> str:
+        # In xonsh, bare `stty echo` is treated as subprocess but the
+        # explicit `$[...]` form is unambiguous inside a sourced script.
+        return "$[stty echo]"
+
+    def ready_marker_command(self) -> str:
+        return f'print({self.READY_MARKER!r}, end="", flush=True)'
+
+    def executable(self) -> str:
+        return "xonsh"

--- a/conda_spawn/main.py
+++ b/conda_spawn/main.py
@@ -11,7 +11,8 @@ from conda.base.context import context, locate_prefix_by_name
 from conda.exceptions import DirectoryNotACondaEnvironmentError
 
 from .exceptions import ShellNotSupported
-from .shell import SHELLS, Shell, detect_shell_class
+from .registry import SHELLS, detect_shell_class
+from .shell import Shell
 
 
 def spawn(

--- a/conda_spawn/main.py
+++ b/conda_spawn/main.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from os.path import expanduser, expandvars, abspath
 from pathlib import Path
-from typing import Type, Iterable
+from typing import TYPE_CHECKING, Type, Iterable
 
 from conda.base.constants import ROOT_ENV_NAME
 from conda.base.context import context, locate_prefix_by_name
@@ -12,7 +12,9 @@ from conda.exceptions import DirectoryNotACondaEnvironmentError
 
 from .exceptions import ShellNotSupported
 from .registry import SHELLS, detect_shell_class
-from .shell import Shell
+
+if TYPE_CHECKING:
+    from .shell import Shell
 
 
 def spawn(

--- a/conda_spawn/registry.py
+++ b/conda_spawn/registry.py
@@ -1,0 +1,58 @@
+"""
+Single source of truth for the `name -> Shell class` mapping used by the
+CLI (`--shell`), the public `spawn`/`hook` entrypoints, and shell
+auto-detection via `shellingham`.
+"""
+
+from __future__ import annotations
+
+import sys
+from logging import getLogger
+
+import shellingham
+
+from .shell import (
+    BashShell,
+    CmdExeShell,
+    PosixShell,
+    PowershellShell,
+    Shell,
+    ZshShell,
+)
+from .contrib import CshShell, FishShell, TcshShell, XonshShell
+
+log = getLogger(f"conda.{__name__}")
+
+SHELLS: dict[str, type[Shell]] = {
+    "ash": PosixShell,
+    "bash": BashShell,
+    "cmd.exe": CmdExeShell,
+    "cmd": CmdExeShell,
+    "csh": CshShell,
+    "dash": PosixShell,
+    "fish": FishShell,
+    "posix": PosixShell,
+    "powershell": PowershellShell,
+    "pwsh": PowershellShell,
+    "tcsh": TcshShell,
+    "xonsh": XonshShell,
+    "zsh": ZshShell,
+}
+
+
+def default_shell_class() -> type[Shell]:
+    if sys.platform == "win32":
+        return CmdExeShell
+    return PosixShell
+
+
+def detect_shell_class() -> type[Shell]:
+    try:
+        name, _ = shellingham.detect_shell()
+    except shellingham.ShellDetectionFailure:
+        return default_shell_class()
+    try:
+        return SHELLS[name]
+    except KeyError:
+        log.warning("Did not recognize shell %s, returning default.", name)
+        return default_shell_class()

--- a/conda_spawn/shell.py
+++ b/conda_spawn/shell.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import shlex
 import shutil
 import signal
@@ -312,12 +313,22 @@ class XonshShell(UnixTTYShell):
         # ``.xsh`` is the canonical extension for xonsh scripts.
         return ".xsh"
 
+    def script(self) -> str:
+        # ``XonshActivator.unset_var_tmpl`` emits ``del $VAR`` which raises
+        # ``KeyError`` when the variable is not already set (e.g. on a fresh
+        # CI runner).  Replace every such line with the safe pop form.
+        raw = super().script()
+        return re.sub(
+            r"^del \$(\w+)$",
+            lambda m: f'${{...}}.pop("{m.group(1)}", None)',
+            raw,
+            flags=re.MULTILINE,
+        )
+
     def prompt(self) -> str:
         # Prepend ``CONDA_PROMPT_MODIFIER`` to ``$PROMPT`` while keeping
         # any format-field tokens in the user's prompt intact.
-        return (
-            "$PROMPT = ${...}.get('CONDA_PROMPT_MODIFIER', '') + $PROMPT"
-        )
+        return "$PROMPT = ${...}.get('CONDA_PROMPT_MODIFIER', '') + $PROMPT"
 
     def _source_command(self, script_path: str) -> str:
         return f'source "{script_path}"'

--- a/conda_spawn/shell.py
+++ b/conda_spawn/shell.py
@@ -78,37 +78,97 @@ class Shell:
                 log.debug("Could not delete %s", path, exc_info=exc)
 
 
-class PosixShell(Shell):
-    Activator = activate.PosixActivator
-    default_shell = "/bin/sh"
-    default_args = ("-l", "-i")
+class UnixTTYShell(Shell):
+    """
+    Common base for Unix-like shells that ``conda spawn`` drives through a
+    pseudo-terminal with ``pexpect``.  Subclasses provide the per-shell
+    bits: ``Activator``, how to source a file, how to set the prompt, how
+    to print the ready marker, and what to strip from the activator's own
+    prompt output.
+    """
 
-    def spawn(self, command: Iterable[str] | None = None) -> int:
-        return self.spawn_tty(command).wait()
-
-    def script(self) -> str:
-        script = self._activator.execute()
-        lines = []
-        for line in script.splitlines(keepends=True):
-            if "PS1=" in line:
-                continue
-            lines.append(line)
-        return "".join(lines)
-
-    def prompt(self) -> str:
-        return f'PS1="{self.prompt_modifier()}${{PS1:-}}"'
-
-    def executable(self):
-        return os.environ.get("SHELL", self.default_shell)
-
-    def args(self):
-        return self.default_args
+    default_shell: str = "/bin/sh"
+    default_args: tuple[str, ...] = ("-l", "-i")
 
     # Sentinel printed after activation to reliably detect when the
     # spawned shell is ready.  Everything before this marker (including
     # any initial prompt rendered with stale env vars) is consumed
     # before `interact()` starts, preventing a duplicate prompt.
     _READY_MARKER = "__CONDA_SPAWN_READY__"
+
+    # Substrings that identify prompt-setting lines emitted by the
+    # activator; those lines are stripped from ``script()`` because
+    # ``prompt()`` installs its own, conda-spawn-friendly prompt.
+    _prompt_strip_markers: tuple[str, ...] = ()
+
+    def spawn(self, command: Iterable[str] | None = None) -> int:
+        return self.spawn_tty(command).wait()
+
+    def script(self) -> str:
+        """Activation script for this shell.
+
+        Mirrors the output of ``conda <shell>.activate`` for this shell
+        (stripped of the activator's own prompt handling where needed).
+        Used both by the ``conda spawn --hook`` flow and as the base
+        content of the temp file sourced by ``spawn_tty``.
+        """
+        script = self._activator.execute()
+        if not self._prompt_strip_markers:
+            return script
+        lines = [
+            line
+            for line in script.splitlines(keepends=True)
+            if not any(marker in line for marker in self._prompt_strip_markers)
+        ]
+        return "".join(lines)
+
+    def _spawn_script(self) -> str:
+        """
+        Full contents of the temp file the spawned shell will source:
+        activation + prompt setup + post-activation command + ready
+        marker.  Stuffing everything into a single sourced file lets
+        multi-line / multi-statement snippets (e.g. fish function defs,
+        xonsh Python statements) run without having to fit into one
+        ``sendline`` call.
+        """
+        parts = [self.script()]
+        for extra in (
+            self.prompt(),
+            self._post_activation_command(),
+            self._ready_marker_command(),
+        ):
+            if extra:
+                parts.append(extra)
+        return "\n".join(p.rstrip("\n") for p in parts) + "\n"
+
+    def prompt(self) -> str:
+        raise NotImplementedError
+
+    def executable(self) -> str:
+        return os.environ.get("SHELL", self.default_shell)
+
+    def args(self) -> tuple[str, ...]:
+        return self.default_args
+
+    @property
+    def _script_suffix(self) -> str:
+        """File suffix used for the temporary activation script."""
+        return self.Activator.script_extension
+
+    def _source_command(self, script_path: str) -> str:
+        """Command that sources ``script_path`` in this shell."""
+        raise NotImplementedError
+
+    def _post_activation_command(self) -> str:
+        """Run after activation; re-enables terminal echo by default."""
+        return "stty echo"
+
+    def _ready_marker_command(self) -> str:
+        """Print the ready marker with no trailing newline."""
+        return f"printf {self._READY_MARKER}"
+
+    def _commandline(self, script_path: str) -> str:
+        return self._source_command(script_path)
 
     def spawn_tty(self, command: Iterable[str] | None = None) -> pexpect.spawn:
         def _sigwinch_passthrough(sig, data):
@@ -134,22 +194,17 @@ class PosixShell(Shell):
         try:
             with NamedTemporaryFile(
                 prefix="conda-spawn-",
-                suffix=self.Activator.script_extension,
+                suffix=self._script_suffix,
                 delete=False,
                 mode="w",
             ) as f:
-                f.write(self.script())
-                # Append prompt setup, echo restore, and the ready marker
-                # to the *same* sourced file so the only thing we sendline
-                # is `. "<path>"`.  If the PTY's input echo is on when the
-                # sendline lands (e.g. zsh rc files / starship init flipped
-                # it back on), the echoed command no longer contains the
-                # marker text -- so it cannot leak through to interact().
-                f.write(f"\n{self.prompt()}\n")
-                f.write("stty echo\n")
-                f.write(f"printf {self._READY_MARKER}\n")
+                f.write(self._spawn_script())
             signal.signal(signal.SIGWINCH, _sigwinch_passthrough)
-            child.sendline(f' . "{f.name}"')
+            # Source the activation script, set the prompt, re-enable echo,
+            # then print a ready marker.  ``expect_exact`` consumes
+            # everything up to and including the marker, so any stale
+            # initial prompt rendered before activation is discarded.
+            child.sendline(self._commandline(f.name))
             child.expect_exact(self._READY_MARKER)
             if command:
                 child.sendline(shlex.join(command))
@@ -158,6 +213,18 @@ class PosixShell(Shell):
             return child
         finally:
             self._files_to_remove.append(f.name)
+
+
+class PosixShell(UnixTTYShell):
+    Activator = activate.PosixActivator
+    default_shell = "/bin/sh"
+    _prompt_strip_markers = ("PS1=",)
+
+    def prompt(self) -> str:
+        return f'PS1="{self.prompt_modifier()}${{PS1:-}}"'
+
+    def _source_command(self, script_path: str) -> str:
+        return f'. "{script_path}"'
 
 
 class BashShell(PosixShell):
@@ -170,16 +237,101 @@ class ZshShell(PosixShell):
         return "zsh"
 
 
-class CshShell(Shell):
-    pass
+class FishShell(UnixTTYShell):
+    Activator = activate.FishActivator
+    default_shell = "fish"
+
+    def prompt(self) -> str:
+        # Preserve any pre-existing ``fish_prompt`` (including ones installed
+        # by prompt tools like starship) and prepend conda's prompt modifier
+        # so users see their env name regardless of their shell setup.
+        return (
+            "if functions -q fish_prompt\n"
+            "    if not functions -q __conda_spawn_orig_fish_prompt\n"
+            "        functions -c fish_prompt __conda_spawn_orig_fish_prompt\n"
+            "        functions -e fish_prompt\n"
+            "    end\n"
+            "end\n"
+            "function fish_prompt\n"
+            '    printf "%s" "$CONDA_PROMPT_MODIFIER"\n'
+            "    if functions -q __conda_spawn_orig_fish_prompt\n"
+            "        __conda_spawn_orig_fish_prompt\n"
+            "    end\n"
+            "end"
+        )
+
+    def _source_command(self, script_path: str) -> str:
+        return f'source "{script_path}"'
+
+    def executable(self) -> str:
+        return "fish"
 
 
-class XonshShell(Shell):
-    pass
+class CshShell(UnixTTYShell):
+    Activator = activate.CshActivator
+    default_shell = "csh"
+    default_args = ("-i",)
+    _prompt_strip_markers = ("set prompt=",)
+
+    def prompt(self) -> str:
+        # csh/tcsh do not define $prompt automatically in all modes; guard
+        # against "Undefined variable" by initialising it to "" if absent.
+        return (
+            'if (! $?prompt) set prompt = ""\n'
+            f'set prompt="{self.prompt_modifier()}${{prompt}}"'
+        )
+
+    def _source_command(self, script_path: str) -> str:
+        return f'source "{script_path}"'
+
+    def _ready_marker_command(self) -> str:
+        # csh does not ship a ``printf`` builtin; ``echo -n`` is portable
+        # across csh/tcsh on the platforms we support.
+        return f'echo -n "{self._READY_MARKER}"'
+
+    def executable(self) -> str:
+        return "csh"
 
 
-class FishShell(Shell):
-    pass
+class TcshShell(CshShell):
+    default_shell = "tcsh"
+
+    def executable(self) -> str:
+        return "tcsh"
+
+
+class XonshShell(UnixTTYShell):
+    Activator = activate.XonshActivator
+    default_shell = "xonsh"
+    default_args = ("-i",)
+
+    @property
+    def _script_suffix(self) -> str:
+        # The ``XonshActivator`` reports ``.sh`` (for bash-sourced
+        # ``activate.d`` scripts) but ``execute()`` emits xonsh syntax.
+        # ``.xsh`` is the canonical extension for xonsh scripts.
+        return ".xsh"
+
+    def prompt(self) -> str:
+        # Prepend ``CONDA_PROMPT_MODIFIER`` to ``$PROMPT`` while keeping
+        # any format-field tokens in the user's prompt intact.
+        return (
+            "$PROMPT = ${...}.get('CONDA_PROMPT_MODIFIER', '') + $PROMPT"
+        )
+
+    def _source_command(self, script_path: str) -> str:
+        return f'source "{script_path}"'
+
+    def _post_activation_command(self) -> str:
+        # In xonsh, bare ``stty echo`` is treated as subprocess but the
+        # explicit ``$[...]`` form is unambiguous inside a sourced script.
+        return "$[stty echo]"
+
+    def _ready_marker_command(self) -> str:
+        return f'print({self._READY_MARKER!r}, end="", flush=True)'
+
+    def executable(self) -> str:
+        return "xonsh"
 
 
 class PowershellShell(Shell):
@@ -274,7 +426,7 @@ SHELLS: dict[str, type[Shell]] = {
     "posix": PosixShell,
     "powershell": PowershellShell,
     "pwsh": PowershellShell,
-    "tcsh": CshShell,
+    "tcsh": TcshShell,
     "xonsh": XonshShell,
     "zsh": ZshShell,
 }

--- a/conda_spawn/shell.py
+++ b/conda_spawn/shell.py
@@ -243,6 +243,14 @@ class ZshShell(PosixShell):
 
 
 class FishShell(UnixShell):
+    """fish shell support.
+
+    Best-effort: not part of the core supported shell matrix (`bash`,
+    `zsh`, `powershell`, `cmd`). It exists to bring `conda spawn` to
+    parity with `conda activate`'s own activator coverage, but is
+    lightly tested and relies on user reports for shell-specific bugs.
+    """
+
     Activator = activate.FishActivator
     default_shell = "fish"
 
@@ -273,6 +281,14 @@ class FishShell(UnixShell):
 
 
 class CshShell(UnixShell):
+    """csh shell support.
+
+    Best-effort: not part of the core supported shell matrix (`bash`,
+    `zsh`, `powershell`, `cmd`). It exists to bring `conda spawn` to
+    parity with `conda activate`'s own activator coverage, but is
+    lightly tested and relies on user reports for shell-specific bugs.
+    """
+
     Activator = activate.CshActivator
     default_shell = "csh"
     default_args = ("-i",)
@@ -299,6 +315,11 @@ class CshShell(UnixShell):
 
 
 class TcshShell(CshShell):
+    """tcsh shell support.
+
+    Inherits the same best-effort caveat as `CshShell`.
+    """
+
     default_shell = "tcsh"
 
     def executable(self) -> str:
@@ -306,6 +327,14 @@ class TcshShell(CshShell):
 
 
 class XonshShell(UnixShell):
+    """xonsh shell support.
+
+    Best-effort: not part of the core supported shell matrix (`bash`,
+    `zsh`, `powershell`, `cmd`). It exists to bring `conda spawn` to
+    parity with `conda activate`'s own activator coverage, but is
+    lightly tested and relies on user reports for shell-specific bugs.
+    """
+
     Activator = activate.XonshActivator
     default_shell = "xonsh"
     default_args = ("-i",)

--- a/conda_spawn/shell.py
+++ b/conda_spawn/shell.py
@@ -72,8 +72,8 @@ class Shell:
         return env
 
     def __del__(self):
-        # ``__init__`` may have failed before ``_files_to_remove`` was set
-        # (e.g. if a subclass forgot to declare ``Activator``).  Guard
+        # `__init__` may have failed before `_files_to_remove` was set
+        # (e.g. if a subclass forgot to declare `Activator`).  Guard
         # against that so the interpreter does not emit a spurious
         # AttributeError during garbage collection.
         for path in getattr(self, "_files_to_remove", ()):
@@ -85,9 +85,9 @@ class Shell:
 
 class UnixShell(Shell):
     """
-    Common base for Unix-like shells that ``conda spawn`` drives through a
-    pseudo-terminal with ``pexpect``.  Subclasses provide the per-shell
-    bits: ``Activator``, how to source a file, how to set the prompt, how
+    Common base for Unix-like shells that `conda spawn` drives through a
+    pseudo-terminal with `pexpect`.  Subclasses provide the per-shell
+    bits: `Activator`, how to source a file, how to set the prompt, how
     to print the ready marker, and what to strip from the activator's own
     prompt output.
     """
@@ -102,8 +102,8 @@ class UnixShell(Shell):
     READY_MARKER = "__CONDA_SPAWN_READY__"
 
     # Substrings that identify prompt-setting lines emitted by the
-    # activator; those lines are stripped from ``script()`` because
-    # ``prompt()`` installs its own, conda-spawn-friendly prompt.
+    # activator; those lines are stripped from `script()` because
+    # `prompt()` installs its own, conda-spawn-friendly prompt.
     prompt_strip_markers: tuple[str, ...] = ()
 
     def spawn(self, command: Iterable[str] | None = None) -> int:
@@ -112,10 +112,10 @@ class UnixShell(Shell):
     def script(self) -> str:
         """Activation script for this shell.
 
-        Mirrors the output of ``conda <shell>.activate`` for this shell
+        Mirrors the output of `conda <shell>.activate` for this shell
         (stripped of the activator's own prompt handling where needed).
-        Used both by the ``conda spawn --hook`` flow and as the base
-        content of the temp file sourced by ``spawn_tty``.
+        Used both by the `conda spawn --hook` flow and as the base
+        content of the temp file sourced by `spawn_tty`.
         """
         script = self._activator.execute()
         if not self.prompt_strip_markers:
@@ -134,7 +134,7 @@ class UnixShell(Shell):
         marker.  Stuffing everything into a single sourced file lets
         multi-line / multi-statement snippets (e.g. fish function defs,
         xonsh Python statements) run without having to fit into one
-        ``sendline`` call.
+        `sendline` call.
         """
         parts = [self.script()]
         for extra in (
@@ -161,7 +161,7 @@ class UnixShell(Shell):
         return self.Activator.script_extension
 
     def source_command(self, script_path: str) -> str:
-        """Command that sources ``script_path`` in this shell."""
+        """Command that sources `script_path` in this shell."""
         raise NotImplementedError
 
     def post_activation_command(self) -> str:
@@ -206,7 +206,7 @@ class UnixShell(Shell):
                 f.write(self._spawn_script())
             signal.signal(signal.SIGWINCH, _sigwinch_passthrough)
             # Source the activation script, set the prompt, re-enable echo,
-            # then print a ready marker.  ``expect_exact`` consumes
+            # then print a ready marker.  `expect_exact` consumes
             # everything up to and including the marker, so any stale
             # initial prompt rendered before activation is discarded.
             child.sendline(self._commandline(f.name))
@@ -247,7 +247,7 @@ class FishShell(UnixShell):
     default_shell = "fish"
 
     def prompt(self) -> str:
-        # Preserve any pre-existing ``fish_prompt`` (including ones installed
+        # Preserve any pre-existing `fish_prompt` (including ones installed
         # by prompt tools like starship) and prepend conda's prompt modifier
         # so users see their env name regardless of their shell setup.
         return (
@@ -290,7 +290,7 @@ class CshShell(UnixShell):
         return f'source "{script_path}"'
 
     def ready_marker_command(self) -> str:
-        # csh does not ship a ``printf`` builtin; ``echo -n`` is portable
+        # csh does not ship a `printf` builtin; `echo -n` is portable
         # across csh/tcsh on the platforms we support.
         return f'echo -n "{self.READY_MARKER}"'
 
@@ -312,14 +312,14 @@ class XonshShell(UnixShell):
 
     @property
     def script_suffix(self) -> str:
-        # The ``XonshActivator`` reports ``.sh`` (for bash-sourced
-        # ``activate.d`` scripts) but ``execute()`` emits xonsh syntax.
-        # ``.xsh`` is the canonical extension for xonsh scripts.
+        # The `XonshActivator` reports `.sh` (for bash-sourced
+        # `activate.d` scripts) but `execute()` emits xonsh syntax.
+        # `.xsh` is the canonical extension for xonsh scripts.
         return ".xsh"
 
     def script(self) -> str:
-        # ``XonshActivator.unset_var_tmpl`` emits ``del $VAR`` which raises
-        # ``KeyError`` when the variable is not already set (e.g. on a fresh
+        # `XonshActivator.unset_var_tmpl` emits `del $VAR` which raises
+        # `KeyError` when the variable is not already set (e.g. on a fresh
         # CI runner).  Replace every such line with the safe pop form.
         raw = super().script()
         return re.sub(
@@ -330,7 +330,7 @@ class XonshShell(UnixShell):
         )
 
     def prompt(self) -> str:
-        # Prepend ``CONDA_PROMPT_MODIFIER`` to ``$PROMPT`` while keeping
+        # Prepend `CONDA_PROMPT_MODIFIER` to `$PROMPT` while keeping
         # any format-field tokens in the user's prompt intact.
         return "$PROMPT = ${...}.get('CONDA_PROMPT_MODIFIER', '') + $PROMPT"
 
@@ -338,8 +338,8 @@ class XonshShell(UnixShell):
         return f'source "{script_path}"'
 
     def post_activation_command(self) -> str:
-        # In xonsh, bare ``stty echo`` is treated as subprocess but the
-        # explicit ``$[...]`` form is unambiguous inside a sourced script.
+        # In xonsh, bare `stty echo` is treated as subprocess but the
+        # explicit `$[...]` form is unambiguous inside a sourced script.
         return "$[stty echo]"
 
     def ready_marker_command(self) -> str:
@@ -392,11 +392,11 @@ class PowershellShell(Shell):
         return "powershell"
 
     def args(self) -> tuple[str, ...]:
-        # ``-NoExit`` keeps PowerShell at its prompt after the activation
-        # script finishes, which is the whole point of ``conda spawn`` for
+        # `-NoExit` keeps PowerShell at its prompt after the activation
+        # script finishes, which is the whole point of `conda spawn` for
         # an interactive user.  Without a TTY on stdin (tests, pipelines)
         # we want PowerShell to exit cleanly once the script is done so the
-        # caller's ``communicate()`` returns instead of relying on a stdin-
+        # caller's `communicate()` returns instead of relying on a stdin-
         # EOF race that can blow past the test's timeout on slow runners.
         if sys.stdin.isatty():
             return ("-NoLogo", "-NoExit", "-File")

--- a/conda_spawn/shell.py
+++ b/conda_spawn/shell.py
@@ -95,12 +95,12 @@ class UnixTTYShell(Shell):
     # spawned shell is ready.  Everything before this marker (including
     # any initial prompt rendered with stale env vars) is consumed
     # before `interact()` starts, preventing a duplicate prompt.
-    _READY_MARKER = "__CONDA_SPAWN_READY__"
+    READY_MARKER = "__CONDA_SPAWN_READY__"
 
     # Substrings that identify prompt-setting lines emitted by the
     # activator; those lines are stripped from ``script()`` because
     # ``prompt()`` installs its own, conda-spawn-friendly prompt.
-    _prompt_strip_markers: tuple[str, ...] = ()
+    prompt_strip_markers: tuple[str, ...] = ()
 
     def spawn(self, command: Iterable[str] | None = None) -> int:
         return self.spawn_tty(command).wait()
@@ -114,12 +114,12 @@ class UnixTTYShell(Shell):
         content of the temp file sourced by ``spawn_tty``.
         """
         script = self._activator.execute()
-        if not self._prompt_strip_markers:
+        if not self.prompt_strip_markers:
             return script
         lines = [
             line
             for line in script.splitlines(keepends=True)
-            if not any(marker in line for marker in self._prompt_strip_markers)
+            if not any(marker in line for marker in self.prompt_strip_markers)
         ]
         return "".join(lines)
 
@@ -135,8 +135,8 @@ class UnixTTYShell(Shell):
         parts = [self.script()]
         for extra in (
             self.prompt(),
-            self._post_activation_command(),
-            self._ready_marker_command(),
+            self.post_activation_command(),
+            self.ready_marker_command(),
         ):
             if extra:
                 parts.append(extra)
@@ -152,24 +152,24 @@ class UnixTTYShell(Shell):
         return self.default_args
 
     @property
-    def _script_suffix(self) -> str:
+    def script_suffix(self) -> str:
         """File suffix used for the temporary activation script."""
         return self.Activator.script_extension
 
-    def _source_command(self, script_path: str) -> str:
+    def source_command(self, script_path: str) -> str:
         """Command that sources ``script_path`` in this shell."""
         raise NotImplementedError
 
-    def _post_activation_command(self) -> str:
+    def post_activation_command(self) -> str:
         """Run after activation; re-enables terminal echo by default."""
         return "stty echo"
 
-    def _ready_marker_command(self) -> str:
+    def ready_marker_command(self) -> str:
         """Print the ready marker with no trailing newline."""
-        return f"printf {self._READY_MARKER}"
+        return f"printf {self.READY_MARKER}"
 
     def _commandline(self, script_path: str) -> str:
-        return self._source_command(script_path)
+        return self.source_command(script_path)
 
     def spawn_tty(self, command: Iterable[str] | None = None) -> pexpect.spawn:
         def _sigwinch_passthrough(sig, data):
@@ -195,7 +195,7 @@ class UnixTTYShell(Shell):
         try:
             with NamedTemporaryFile(
                 prefix="conda-spawn-",
-                suffix=self._script_suffix,
+                suffix=self.script_suffix,
                 delete=False,
                 mode="w",
             ) as f:
@@ -206,7 +206,7 @@ class UnixTTYShell(Shell):
             # everything up to and including the marker, so any stale
             # initial prompt rendered before activation is discarded.
             child.sendline(self._commandline(f.name))
-            child.expect_exact(self._READY_MARKER)
+            child.expect_exact(self.READY_MARKER)
             if command:
                 child.sendline(shlex.join(command))
             if sys.stdin.isatty():
@@ -219,12 +219,12 @@ class UnixTTYShell(Shell):
 class PosixShell(UnixTTYShell):
     Activator = activate.PosixActivator
     default_shell = "/bin/sh"
-    _prompt_strip_markers = ("PS1=",)
+    prompt_strip_markers = ("PS1=",)
 
     def prompt(self) -> str:
         return f'PS1="{self.prompt_modifier()}${{PS1:-}}"'
 
-    def _source_command(self, script_path: str) -> str:
+    def source_command(self, script_path: str) -> str:
         return f'. "{script_path}"'
 
 
@@ -261,7 +261,7 @@ class FishShell(UnixTTYShell):
             "end"
         )
 
-    def _source_command(self, script_path: str) -> str:
+    def source_command(self, script_path: str) -> str:
         return f'source "{script_path}"'
 
     def executable(self) -> str:
@@ -272,7 +272,7 @@ class CshShell(UnixTTYShell):
     Activator = activate.CshActivator
     default_shell = "csh"
     default_args = ("-i",)
-    _prompt_strip_markers = ("set prompt=",)
+    prompt_strip_markers = ("set prompt=",)
 
     def prompt(self) -> str:
         # csh/tcsh do not define $prompt automatically in all modes; guard
@@ -282,13 +282,13 @@ class CshShell(UnixTTYShell):
             f'set prompt="{self.prompt_modifier()}${{prompt}}"'
         )
 
-    def _source_command(self, script_path: str) -> str:
+    def source_command(self, script_path: str) -> str:
         return f'source "{script_path}"'
 
-    def _ready_marker_command(self) -> str:
+    def ready_marker_command(self) -> str:
         # csh does not ship a ``printf`` builtin; ``echo -n`` is portable
         # across csh/tcsh on the platforms we support.
-        return f'echo -n "{self._READY_MARKER}"'
+        return f'echo -n "{self.READY_MARKER}"'
 
     def executable(self) -> str:
         return "csh"
@@ -307,7 +307,7 @@ class XonshShell(UnixTTYShell):
     default_args = ("-i",)
 
     @property
-    def _script_suffix(self) -> str:
+    def script_suffix(self) -> str:
         # The ``XonshActivator`` reports ``.sh`` (for bash-sourced
         # ``activate.d`` scripts) but ``execute()`` emits xonsh syntax.
         # ``.xsh`` is the canonical extension for xonsh scripts.
@@ -330,16 +330,16 @@ class XonshShell(UnixTTYShell):
         # any format-field tokens in the user's prompt intact.
         return "$PROMPT = ${...}.get('CONDA_PROMPT_MODIFIER', '') + $PROMPT"
 
-    def _source_command(self, script_path: str) -> str:
+    def source_command(self, script_path: str) -> str:
         return f'source "{script_path}"'
 
-    def _post_activation_command(self) -> str:
+    def post_activation_command(self) -> str:
         # In xonsh, bare ``stty echo`` is treated as subprocess but the
         # explicit ``$[...]`` form is unambiguous inside a sourced script.
         return "$[stty echo]"
 
-    def _ready_marker_command(self) -> str:
-        return f'print({self._READY_MARKER!r}, end="", flush=True)'
+    def ready_marker_command(self) -> str:
+        return f'print({self.READY_MARKER!r}, end="", flush=True)'
 
     def executable(self) -> str:
         return "xonsh"

--- a/conda_spawn/shell.py
+++ b/conda_spawn/shell.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import re
 import shlex
 import shutil
 import signal
@@ -18,8 +17,6 @@ if sys.platform != "win32":
     import termios
 
     import pexpect
-
-import shellingham
 
 from . import activate
 
@@ -242,142 +239,6 @@ class ZshShell(PosixShell):
         return "zsh"
 
 
-class FishShell(UnixShell):
-    """fish shell support.
-
-    Best-effort: not part of the core supported shell matrix (`bash`,
-    `zsh`, `powershell`, `cmd`). It exists to bring `conda spawn` to
-    parity with `conda activate`'s own activator coverage, but is
-    lightly tested and relies on user reports for shell-specific bugs.
-    """
-
-    Activator = activate.FishActivator
-    default_shell = "fish"
-
-    def prompt(self) -> str:
-        # Preserve any pre-existing `fish_prompt` (including ones installed
-        # by prompt tools like starship) and prepend conda's prompt modifier
-        # so users see their env name regardless of their shell setup.
-        return (
-            "if functions -q fish_prompt\n"
-            "    if not functions -q __conda_spawn_orig_fish_prompt\n"
-            "        functions -c fish_prompt __conda_spawn_orig_fish_prompt\n"
-            "        functions -e fish_prompt\n"
-            "    end\n"
-            "end\n"
-            "function fish_prompt\n"
-            '    printf "%s" "$CONDA_PROMPT_MODIFIER"\n'
-            "    if functions -q __conda_spawn_orig_fish_prompt\n"
-            "        __conda_spawn_orig_fish_prompt\n"
-            "    end\n"
-            "end"
-        )
-
-    def source_command(self, script_path: str) -> str:
-        return f'source "{script_path}"'
-
-    def executable(self) -> str:
-        return "fish"
-
-
-class CshShell(UnixShell):
-    """csh shell support.
-
-    Best-effort: not part of the core supported shell matrix (`bash`,
-    `zsh`, `powershell`, `cmd`). It exists to bring `conda spawn` to
-    parity with `conda activate`'s own activator coverage, but is
-    lightly tested and relies on user reports for shell-specific bugs.
-    """
-
-    Activator = activate.CshActivator
-    default_shell = "csh"
-    default_args = ("-i",)
-    prompt_strip_markers = ("set prompt=",)
-
-    def prompt(self) -> str:
-        # csh/tcsh do not define $prompt automatically in all modes; guard
-        # against "Undefined variable" by initialising it to "" if absent.
-        return (
-            'if (! $?prompt) set prompt = ""\n'
-            f'set prompt="{self.prompt_modifier()}${{prompt}}"'
-        )
-
-    def source_command(self, script_path: str) -> str:
-        return f'source "{script_path}"'
-
-    def ready_marker_command(self) -> str:
-        # csh does not ship a `printf` builtin; `echo -n` is portable
-        # across csh/tcsh on the platforms we support.
-        return f'echo -n "{self.READY_MARKER}"'
-
-    def executable(self) -> str:
-        return "csh"
-
-
-class TcshShell(CshShell):
-    """tcsh shell support.
-
-    Inherits the same best-effort caveat as `CshShell`.
-    """
-
-    default_shell = "tcsh"
-
-    def executable(self) -> str:
-        return "tcsh"
-
-
-class XonshShell(UnixShell):
-    """xonsh shell support.
-
-    Best-effort: not part of the core supported shell matrix (`bash`,
-    `zsh`, `powershell`, `cmd`). It exists to bring `conda spawn` to
-    parity with `conda activate`'s own activator coverage, but is
-    lightly tested and relies on user reports for shell-specific bugs.
-    """
-
-    Activator = activate.XonshActivator
-    default_shell = "xonsh"
-    default_args = ("-i",)
-
-    @property
-    def script_suffix(self) -> str:
-        # The `XonshActivator` reports `.sh` (for bash-sourced
-        # `activate.d` scripts) but `execute()` emits xonsh syntax.
-        # `.xsh` is the canonical extension for xonsh scripts.
-        return ".xsh"
-
-    def script(self) -> str:
-        # `XonshActivator.unset_var_tmpl` emits `del $VAR` which raises
-        # `KeyError` when the variable is not already set (e.g. on a fresh
-        # CI runner).  Replace every such line with the safe pop form.
-        raw = super().script()
-        return re.sub(
-            r"^del \$(\w+)$",
-            lambda m: f'${{...}}.pop("{m.group(1)}", None)',
-            raw,
-            flags=re.MULTILINE,
-        )
-
-    def prompt(self) -> str:
-        # Prepend `CONDA_PROMPT_MODIFIER` to `$PROMPT` while keeping
-        # any format-field tokens in the user's prompt intact.
-        return "$PROMPT = ${...}.get('CONDA_PROMPT_MODIFIER', '') + $PROMPT"
-
-    def source_command(self, script_path: str) -> str:
-        return f'source "{script_path}"'
-
-    def post_activation_command(self) -> str:
-        # In xonsh, bare `stty echo` is treated as subprocess but the
-        # explicit `$[...]` form is unambiguous inside a sourced script.
-        return "$[stty echo]"
-
-    def ready_marker_command(self) -> str:
-        return f'print({self.READY_MARKER!r}, end="", flush=True)'
-
-    def executable(self) -> str:
-        return "xonsh"
-
-
 class PowershellShell(Shell):
     Activator = activate.PowerShellActivator
 
@@ -457,39 +318,3 @@ class CmdExeShell(PowershellShell):
 
     def args(self) -> tuple[str, ...]:
         return ("/D", "/K")
-
-
-SHELLS: dict[str, type[Shell]] = {
-    "ash": PosixShell,
-    "bash": BashShell,
-    "cmd.exe": CmdExeShell,
-    "cmd": CmdExeShell,
-    "csh": CshShell,
-    "dash": PosixShell,
-    "fish": FishShell,
-    "posix": PosixShell,
-    "powershell": PowershellShell,
-    "pwsh": PowershellShell,
-    "tcsh": TcshShell,
-    "xonsh": XonshShell,
-    "zsh": ZshShell,
-}
-
-
-def default_shell_class():
-    if sys.platform == "win32":
-        return CmdExeShell
-    return PosixShell
-
-
-def detect_shell_class():
-    try:
-        name, _ = shellingham.detect_shell()
-    except shellingham.ShellDetectionFailure:
-        return default_shell_class()
-    else:
-        try:
-            return SHELLS[name]
-        except KeyError:
-            log.warning("Did not recognize shell %s, returning default.", name)
-            return default_shell_class()

--- a/conda_spawn/shell.py
+++ b/conda_spawn/shell.py
@@ -72,14 +72,18 @@ class Shell:
         return env
 
     def __del__(self):
-        for path in self._files_to_remove:
+        # ``__init__`` may have failed before ``_files_to_remove`` was set
+        # (e.g. if a subclass forgot to declare ``Activator``).  Guard
+        # against that so the interpreter does not emit a spurious
+        # AttributeError during garbage collection.
+        for path in getattr(self, "_files_to_remove", ()):
             try:
                 os.unlink(path)
             except OSError as exc:
                 log.debug("Could not delete %s", path, exc_info=exc)
 
 
-class UnixTTYShell(Shell):
+class UnixShell(Shell):
     """
     Common base for Unix-like shells that ``conda spawn`` drives through a
     pseudo-terminal with ``pexpect``.  Subclasses provide the per-shell
@@ -216,7 +220,7 @@ class UnixTTYShell(Shell):
             self._files_to_remove.append(f.name)
 
 
-class PosixShell(UnixTTYShell):
+class PosixShell(UnixShell):
     Activator = activate.PosixActivator
     default_shell = "/bin/sh"
     prompt_strip_markers = ("PS1=",)
@@ -238,7 +242,7 @@ class ZshShell(PosixShell):
         return "zsh"
 
 
-class FishShell(UnixTTYShell):
+class FishShell(UnixShell):
     Activator = activate.FishActivator
     default_shell = "fish"
 
@@ -268,7 +272,7 @@ class FishShell(UnixTTYShell):
         return "fish"
 
 
-class CshShell(UnixTTYShell):
+class CshShell(UnixShell):
     Activator = activate.CshActivator
     default_shell = "csh"
     default_args = ("-i",)
@@ -301,7 +305,7 @@ class TcshShell(CshShell):
         return "tcsh"
 
 
-class XonshShell(UnixTTYShell):
+class XonshShell(UnixShell):
     Activator = activate.XonshActivator
     default_shell = "xonsh"
     default_args = ("-i",)

--- a/pixi.lock
+++ b/pixi.lock
@@ -7575,7 +7575,7 @@ packages:
   timestamp: 1751548225624
 - pypi: ./
   name: conda-spawn
-  version: 0.0.6.dev21+g4623cca67.d20260424
+  version: 0.0.6.dev23+g1c9500b55.d20260424
   sha256: 8e98bb2ac2e8271cc97560c5b813fd3bb891efaabb8a0368fac8884625a3f85e
   requires_dist:
   - pexpect

--- a/pixi.lock
+++ b/pixi.lock
@@ -1819,7 +1819,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/fish-4.6.0-ha09e916_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-11.0.2-h3c5361c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.6-py310hb9d19b6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
@@ -1853,7 +1852,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsolv-0.7.30-h69d5d9b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.2-hdb6dae5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-h3dc7d44_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcrypt-4.4.36-h10d778d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.5-he8ee3e7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-17.0.6-hbedff68_1.conda
@@ -1868,25 +1866,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hc426f3f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/patch-2.7.6-hbcf498f_1002.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.1-py310hbb8c376_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/py-lief-0.14.1-py310h53e7c6a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pycosat-0.6.6-py310hbb8c376_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.0-py310hae5a141_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.0-py310hae5a141_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.12.0-pyhd8ed1ab_0.conda
@@ -1904,7 +1895,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.22.3-py310h98870a7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.10-py310hbb8c376_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.8-py310hb9d19b6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py310h8bcfd8d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
@@ -1912,7 +1902,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.15.0-h0ec5880_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/tcsh-6.24.16-h7768305_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
@@ -1921,8 +1910,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.0.1-py310hfa8da69_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.19.10-py310h2ec42d9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-he965462_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
@@ -2141,16 +2128,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.1-py310ha8f682b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/py-lief-0.14.1-py310h9e98ed7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/pycosat-0.6.6-py310ha8f682b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.12.0-pyhd8ed1ab_0.conda
@@ -2167,7 +2150,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.22.3-py310hc226416_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.10-py310ha8f682b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.8-py310ha8f682b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/setproctitle-1.3.7-py310h1637853_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/simdjson-3.11.5-hc790b64_0.conda
@@ -2186,9 +2168,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.44.35208-h38c0c73_34.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/xonsh-0.19.10-py310h5588dad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-cpp-0.8.0-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
@@ -2385,7 +2365,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/fish-4.6.0-ha09e916_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-11.0.2-h3c5361c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.6-py311h1314207_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
@@ -2420,7 +2399,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsolv-0.7.30-h69d5d9b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.2-hdb6dae5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-h3dc7d44_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcrypt-4.4.36-h10d778d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.5-he8ee3e7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-17.0.6-hbedff68_1.conda
@@ -2435,25 +2413,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hc426f3f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/patch-2.7.6-hbcf498f_1002.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.1-py311h4d7f069_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/py-lief-0.14.1-py311hd89902b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pycosat-0.6.6-py311h4d7f069_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.0-py311hfbc4093_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.0-py311hfbc4093_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.12.0-pyhd8ed1ab_0.conda
@@ -2471,7 +2442,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.22.3-py311h3b9c2be_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.10-py311h4d7f069_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.8-py311h1314207_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py311ha332486_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
@@ -2479,7 +2449,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.15.0-h0ec5880_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/tcsh-6.24.16-h7768305_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
@@ -2488,8 +2457,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.0.1-py311hf2f7c97_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py311h6eed73b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-he965462_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
@@ -2710,16 +2677,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.1-py311he736701_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/py-lief-0.14.1-py311hda3d55a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/pycosat-0.6.6-py311he736701_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.12.0-pyhd8ed1ab_0.conda
@@ -2736,7 +2699,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.22.3-py311h533ab2d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.10-py311he736701_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.8-py311he736701_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/setproctitle-1.3.7-py311hf893f09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/simdjson-3.11.5-hc790b64_0.conda
@@ -2755,9 +2717,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.44.35208-h38c0c73_34.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/xonsh-0.23.1-py311h1ea47a8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-cpp-0.8.0-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
@@ -2954,7 +2914,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/fish-4.6.0-ha09e916_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-11.0.2-h3c5361c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.6-py312h3d0f464_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
@@ -2989,7 +2948,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsolv-0.7.30-h69d5d9b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.2-hdb6dae5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-h3dc7d44_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcrypt-4.4.36-h10d778d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.5-he8ee3e7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-17.0.6-hbedff68_1.conda
@@ -3004,25 +2962,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hc426f3f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/patch-2.7.6-hbcf498f_1002.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.1-py312h01d7ebd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/py-lief-0.14.1-py312h5861a67_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pycosat-0.6.6-py312h01d7ebd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.0-py312h2365019_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.0-py312h2365019_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.12.0-pyhd8ed1ab_0.conda
@@ -3040,7 +2991,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.22.3-py312h0d0de52_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.10-py312h01d7ebd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.8-py312h3d0f464_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py312hf7082af_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
@@ -3048,7 +2998,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.15.0-h0ec5880_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/tcsh-6.24.16-h7768305_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
@@ -3057,8 +3006,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.0.1-py312hc5c4d5f_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py312hb401068_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-he965462_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
@@ -3279,16 +3226,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.1-py312h4389bb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/py-lief-0.14.1-py312h275cf98_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/pycosat-0.6.6-py312h4389bb4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.12.0-pyhd8ed1ab_0.conda
@@ -3305,7 +3248,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.22.3-py312h2615798_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.10-py312h4389bb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.8-py312h4389bb4_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/setproctitle-1.3.7-py312he5662c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/simdjson-3.11.5-hc790b64_0.conda
@@ -3324,9 +3266,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.44.35208-h38c0c73_34.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/xonsh-0.23.1-py312h2e8e312_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-cpp-0.8.0-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
@@ -3532,7 +3472,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/evalidate-2.0.5-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/fish-4.6.0-ha09e916_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-12.1.0-hda137b5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.7-py313hf050af9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
@@ -3571,7 +3510,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsolv-0.7.36-hf97c9bc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.0-h8f8c405_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-hed3591d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcrypt-4.4.36-h10d778d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
@@ -3589,14 +3527,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/patch-2.8-h8616949_1002.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.2.2-py313h16366db_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/py-lief-0.17.6-py313hbc4457e_0.conda
@@ -3604,9 +3539,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pycosat-0.6.6-py313h585f44e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-12.1-py313h07bcf3a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.1-py313hf669bc3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -3625,7 +3557,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.30.0-py313hcc225dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.17-py313h16366db_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.15-py313h16366db_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py313h16366db_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-codesign-0.1.3-hc0f2934_0.conda
@@ -3633,7 +3564,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.17.0-h30f01e4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1600.0.11.8-h8d8e812_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/tcsh-6.24.16-h7768305_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
@@ -3644,8 +3574,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.1.0-py313h252b9d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.2.4-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py313habf4b1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-h92383a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
@@ -3879,8 +3807,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.2.2-py313h5fd188c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/py-lief-0.17.6-py313hfe59770_0.conda
@@ -3888,7 +3814,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pycosat-0.6.6-py313h5ea7bf4_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -3906,7 +3831,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.30.0-py313hfbe8231_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.17-py313h5fd188c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py313h5fd188c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/setproctitle-1.3.7-py313h5fd188c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/simdjson-4.2.4-h49e36cd_0.conda
@@ -3926,9 +3850,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.2.4-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/xonsh-0.23.1-py313hfa70ccb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-cpp-0.8.0-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
@@ -4134,7 +4056,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/evalidate-2.0.5-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/fish-4.6.0-ha09e916_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-12.1.0-hda137b5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.7-py314h6482030_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
@@ -4173,7 +4094,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsolv-0.7.36-hf97c9bc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.0-h8f8c405_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-hed3591d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcrypt-4.4.36-h10d778d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
@@ -4191,14 +4111,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/patch-2.8-h8616949_1002.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.2.2-py314hd330473_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/py-lief-0.17.6-py314h7008281_0.conda
@@ -4206,9 +4123,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pycosat-0.6.6-py314h03d016b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-12.1-py314h681fd4f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.1-py314h9720295_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -4227,7 +4141,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.30.0-py314ha7b6dee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.17-py314hd330473_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.15-py314hd330473_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py314hd330473_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-codesign-0.1.3-hc0f2934_0.conda
@@ -4235,7 +4148,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.17.0-h30f01e4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1600.0.11.8-h8d8e812_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/tcsh-6.24.16-h7768305_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
@@ -4246,8 +4158,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.1.0-py314h473ef84_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.2.4-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py314hee6578b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-h92383a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
@@ -4481,8 +4391,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.2.2-py314hc5dbbe4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/py-lief-0.17.6-py314h13fbf68_0.conda
@@ -4490,7 +4398,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pycosat-0.6.6-py314h5a2d7ad_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -4508,7 +4415,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.30.0-py314h9f07db2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.17-py314hc5dbbe4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py314hc5dbbe4_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/setproctitle-1.3.7-py314hc5dbbe4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/simdjson-4.2.4-h49e36cd_0.conda
@@ -4528,9 +4434,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.2.4-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/xonsh-0.23.1-py314h86ab7b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-cpp-0.8.0-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
@@ -7608,8 +7512,8 @@ packages:
   timestamp: 1751548225624
 - pypi: ./
   name: conda-spawn
-  version: 0.0.6.dev18+g177a5ba80.d20260424
-  sha256: 565055247d30f3d125d315f8b94039ac6859322112e9bf7ee7095db493c24b08
+  version: 0.0.6.dev20+gc0f3ae7e4.d20260424
+  sha256: 0402df1b6935d76e65b52c0a8f053326676556a363e702e16ed65fa877c2929c
   requires_dist:
   - pexpect
   - shellingham
@@ -7822,20 +7726,6 @@ packages:
   purls: []
   size: 10832475
   timestamp: 1774679111989
-- conda: https://conda.anaconda.org/conda-forge/osx-64/fish-4.6.0-ha09e916_0.conda
-  sha256: d0d33159bc5e08710646363c8cfc4aa9c3d03f8f5a36308a01a356a8112987e9
-  md5: d738fa29d86a810993fefec866978610
-  depends:
-  - __osx >=11.0
-  - ncurses >=6.5,<7.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  constrains:
-  - __osx >=10.13
-  license: GPL-2.0-only
-  license_family: GPL
-  purls: []
-  size: 10616294
-  timestamp: 1774679256083
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fish-4.6.0-h6f4fc28_0.conda
   sha256: 08ea663ecb5f60481b5798d48d179597e90102e35c41b73c4a74bb3d98b29df3
   md5: b672e875a12fca11231789278071a265
@@ -11392,13 +11282,6 @@ packages:
   purls: []
   size: 100393
   timestamp: 1702724383534
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libxcrypt-4.4.36-h10d778d_1.conda
-  sha256: 7f438b1491326da20433b486efdbdfac3fe7b105676f44bcd4fb9a306a773b5c
-  md5: c4497a698d8b932569aff7e1c15765de
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 97816
-  timestamp: 1702724522480
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-h0d44e9d_1.conda
   sha256: 306e18aa647d8208ad2cd0e62d84933222b2fbe93d2d53cd5283d2256b1d54de
   md5: f5b05674697ae7d2c5932766695945e1
@@ -13270,18 +13153,6 @@ packages:
   purls: []
   size: 1222481
   timestamp: 1763655398280
-- conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
-  sha256: 8d64a9d36073346542e5ea042ef8207a45a0069a2e65ce3323ee3146db78134c
-  md5: 08f970fb2b75f5be27678e077ebedd46
-  depends:
-  - __osx >=10.13
-  - bzip2 >=1.0.8,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 1106584
-  timestamp: 1763655837207
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.47-h30297fc_0.conda
   sha256: 5e2e443f796f2fd92adf7978286a525fb768c34e12b1ee9ded4000a41b2894ba
   md5: 9b4190c4055435ca3502070186eba53a
@@ -14454,81 +14325,6 @@ packages:
   - pkg:pypi/pygments?source=compressed-mapping
   size: 893031
   timestamp: 1774796815820
-- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.0-py310hae5a141_0.conda
-  sha256: 5f2cf2f8ab52cbc6a4fdf52a8e60f142e8925a090ea2a7c207f37e275abed522
-  md5: 2bcbeb72c360a1f07c3719a0c40ab173
-  depends:
-  - __osx >=10.13
-  - libffi >=3.4,<4.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - setuptools
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pyobjc-core?source=hash-mapping
-  size: 440659
-  timestamp: 1736891377279
-- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.0-py311hfbc4093_0.conda
-  sha256: 7cc9dd5c836631c733173c88187231bfc0438135e0ddf94e866e45b3d10592bd
-  md5: 3b2f520d27fa7cf9c6c73fb43c69a321
-  depends:
-  - __osx >=10.13
-  - libffi >=3.4,<4.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - setuptools
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pyobjc-core?source=hash-mapping
-  size: 489258
-  timestamp: 1736891091428
-- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.0-py312h2365019_0.conda
-  sha256: 91a27ede294fec129d115f2e0b0ce881f0c12332ee5e9c33ba522c037ad14bbb
-  md5: 0925c0e6ee32098c461423ea93490b97
-  depends:
-  - __osx >=10.13
-  - libffi >=3.4,<4.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - setuptools
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pyobjc-core?source=hash-mapping
-  size: 489634
-  timestamp: 1736891165910
-- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-12.1-py313h07bcf3a_0.conda
-  sha256: 1e0edd34b804e20ba064dcebcfce3066d841ec812f29ed65902da7192af617d1
-  md5: 6a2c3a617a70f97ca53b7b88461b1c27
-  depends:
-  - __osx >=10.13
-  - libffi >=3.5.2,<3.6.0a0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - setuptools
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pyobjc-core?source=hash-mapping
-  size: 491157
-  timestamp: 1763151415674
-- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-12.1-py314h681fd4f_0.conda
-  sha256: f95c247d52009fd29887904a3ca1556ffd6cf0bff225b63f914c7b294007100a
-  md5: eea444aa695378a47d13a974a31c893d
-  depends:
-  - __osx >=10.13
-  - libffi >=3.5.2,<3.6.0a0
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  - setuptools
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pyobjc-core?source=hash-mapping
-  size: 491826
-  timestamp: 1763151541038
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.0-py310h4e4eb3c_0.conda
   sha256: ef1860dd429d8294d8d3c819e7f2f63b54095321c6a589f333d3ffe67d4d7857
   md5: 113f27b3a820a326335e11dca0a0a032
@@ -14609,81 +14405,6 @@ packages:
   - pkg:pypi/pyobjc-core?source=hash-mapping
   size: 483374
   timestamp: 1763151489724
-- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.0-py310hae5a141_0.conda
-  sha256: dcf0154027aaa49eebd6095457b45666ec8430ee0b9e701701f801a6944cc2ee
-  md5: d61b4a008a1fa7443c549520ce041a25
-  depends:
-  - __osx >=10.13
-  - libffi >=3.4,<4.0a0
-  - pyobjc-core 11.0.*
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
-  size: 337668
-  timestamp: 1736927235562
-- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.0-py311hfbc4093_0.conda
-  sha256: 94e00e4c9b5c5d8b2374321a0f908b7812b06ac8c9cb99242ddaa4ea0091f0be
-  md5: d16654f6b3f602bb0acab446c55bcafb
-  depends:
-  - __osx >=10.13
-  - libffi >=3.4,<4.0a0
-  - pyobjc-core 11.0.*
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
-  size: 385111
-  timestamp: 1736927116099
-- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.0-py312h2365019_0.conda
-  sha256: 974fc6659f162a6e9cf201e5544f32d5c38d795a1141b327f87be2821dc7bf07
-  md5: 2486dd4f176f772531e0ecf22a8b85bd
-  depends:
-  - __osx >=10.13
-  - libffi >=3.4,<4.0a0
-  - pyobjc-core 11.0.*
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
-  size: 381786
-  timestamp: 1736927108218
-- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.1-py313hf669bc3_0.conda
-  sha256: 4761b8448bb9ecfcd9636a506104e6474e0f4cb73d108f2088997702ae984a00
-  md5: 628b5ad83d6140fe4bfa937e2f357ed7
-  depends:
-  - __osx >=10.13
-  - libffi >=3.5.2,<3.6.0a0
-  - pyobjc-core 12.1.*
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
-  size: 374120
-  timestamp: 1763160397755
-- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.1-py314h9720295_0.conda
-  sha256: b1a54bbe3223a919e33778ee70c74756305f7fd14b7e739f4df8d576783a78ca
-  md5: 992ab0e7362326773eb8c2afa5c28a71
-  depends:
-  - __osx >=10.13
-  - libffi >=3.5.2,<3.6.0a0
-  - pyobjc-core 12.1.*
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
-  size: 374960
-  timestamp: 1763160496034
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.0-py310h4e4eb3c_0.conda
   sha256: 2dbc1f27b4f131ee7ca7386f205d002cb45fb9919c3a042901b971e10aca33c6
   md5: 6fe7f5e5ac9c83f5d1942b5d96e4f9b3
@@ -14777,18 +14498,6 @@ packages:
   - pkg:pypi/pyperclip?source=hash-mapping
   size: 17000
   timestamp: 1758906964482
-- conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh7428d3b_0.conda
-  sha256: 4c45cfde1f904a8b85450bb9803391dc4f2d658ecbdafa2313289e2dc3c8480a
-  md5: 66b53fbb78773cd282164fcf08878957
-  depends:
-  - __win
-  - python >=3.10
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/pyperclip?source=hash-mapping
-  size: 17362
-  timestamp: 1758906942340
 - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyha804496_0.conda
   sha256: 977fa57882322d2ed29ad54bc0084d79c27fde57f150be39923f2c0824fc3205
   md5: 2054f5088a57280a8ea79df3d5341728
@@ -17673,71 +17382,6 @@ packages:
   - pkg:pypi/setproctitle?source=hash-mapping
   size: 23438
   timestamp: 1766684440482
-- conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py310h8bcfd8d_0.conda
-  sha256: 9ab8401a1b0b6a7ccd3bec866ff13702bd5ac7ebec466608e20cde3e204b030f
-  md5: 487dbddb77a1041825e5f4d05c8bc793
-  depends:
-  - python
-  - __osx >=10.13
-  - python_abi 3.10.* *_cp310
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/setproctitle?source=hash-mapping
-  size: 21585
-  timestamp: 1766684443530
-- conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py311ha332486_0.conda
-  sha256: 343ebd90baa78d976c0da4eba67001d7446c38543cd706182de2d8ee42ffb862
-  md5: 67b18b09998932da94cfe958697169c4
-  depends:
-  - python
-  - __osx >=10.13
-  - python_abi 3.11.* *_cp311
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/setproctitle?source=hash-mapping
-  size: 21924
-  timestamp: 1766684439140
-- conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py312hf7082af_0.conda
-  sha256: 13b4a05e5554964b02e42fae309a619072a04e4f474a32c395f9470a957e7291
-  md5: 86753db84cac12fd00516d7dcfb7ac81
-  depends:
-  - python
-  - __osx >=10.13
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/setproctitle?source=hash-mapping
-  size: 21891
-  timestamp: 1766684445937
-- conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py313h16366db_0.conda
-  sha256: e0e0d6a04fc9680a081422723744cfd5a2844e46031492ead46697f624b7a14b
-  md5: 41cdd01b06386ef60b73c96d082793ea
-  depends:
-  - python
-  - __osx >=10.13
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/setproctitle?source=hash-mapping
-  size: 22021
-  timestamp: 1766684444946
-- conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py314hd330473_0.conda
-  sha256: e73e0e6208732bf69747c25ac9fe4d029cde3054569832da7e5e2c8832738aac
-  md5: b06b7a4d54691533591ce0a9c59d88b5
-  depends:
-  - python
-  - __osx >=10.13
-  - python_abi 3.14.* *_cp314
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/setproctitle?source=hash-mapping
-  size: 22166
-  timestamp: 1766684437572
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/setproctitle-1.3.7-py310haea493c_0.conda
   sha256: 90dd3397e4db3e325838f6fefaa9481998534068d300f8eb0900e36603504b2e
   md5: 6abf3c8c9d18d356c4b3c9622b02768d
@@ -17808,81 +17452,6 @@ packages:
   - pkg:pypi/setproctitle?source=hash-mapping
   size: 24666
   timestamp: 1766684438889
-- conda: https://conda.anaconda.org/conda-forge/win-64/setproctitle-1.3.7-py310h1637853_0.conda
-  sha256: 858de5ed8675808081d85bffd725df8a2a753e9aeffa99d625821345831f40af
-  md5: 577c16e6125cef95a2eb989cd9051003
-  depends:
-  - python
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - python_abi 3.10.* *_cp310
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/setproctitle?source=hash-mapping
-  size: 20316
-  timestamp: 1766684462922
-- conda: https://conda.anaconda.org/conda-forge/win-64/setproctitle-1.3.7-py311hf893f09_0.conda
-  sha256: a2755b6bc8fc3600042db75c3c958ca0346fc5ac7b64e5d0b3ed524ac10d7c95
-  md5: 0e8ea84cebe19bb782d3804250b856a1
-  depends:
-  - python
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/setproctitle?source=hash-mapping
-  size: 20645
-  timestamp: 1766684463149
-- conda: https://conda.anaconda.org/conda-forge/win-64/setproctitle-1.3.7-py312he5662c2_0.conda
-  sha256: 3dd469892d73933c3e5f28cee9767e966909031f2d9f7b076faca3ae9cfdfd15
-  md5: 33aedb12042c55dd66a17e77fb061d50
-  depends:
-  - python
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/setproctitle?source=hash-mapping
-  size: 20586
-  timestamp: 1766684461382
-- conda: https://conda.anaconda.org/conda-forge/win-64/setproctitle-1.3.7-py313h5fd188c_0.conda
-  sha256: 572b465da620182304e292765f0d163569a7fa400165337b08ff9d8c316ce565
-  md5: f920906a4b8ae72e450e5f59eab48e21
-  depends:
-  - python
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/setproctitle?source=hash-mapping
-  size: 20733
-  timestamp: 1766684466490
-- conda: https://conda.anaconda.org/conda-forge/win-64/setproctitle-1.3.7-py314hc5dbbe4_0.conda
-  sha256: 8f293ce82ae8974a6c8f9905e3de8bcc37baf20053fd53f14c91a3393302e88a
-  md5: 1c0042a95d57ff6a57a2c1f7ba72a7b2
-  depends:
-  - python
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - python_abi 3.14.* *_cp314
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/setproctitle?source=hash-mapping
-  size: 20989
-  timestamp: 1766684462447
 - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
   sha256: e0778e4f276e9a81b51c56f51ec22a27b4d8fc955abc0be77ad09ca9bea06bb9
   md5: 8f28e299c11afdd79e0ec1e279dcdc52
@@ -18434,18 +18003,6 @@ packages:
   purls: []
   size: 386085
   timestamp: 1752068404654
-- conda: https://conda.anaconda.org/conda-forge/osx-64/tcsh-6.24.16-h7768305_0.conda
-  sha256: 77cc914f8c46439949f520e6386d9df5f3c7419bf3fe0c19b54ed2cd07b2717f
-  md5: 1a4cb84b92858150a1ecc6ffc7804b12
-  depends:
-  - __osx >=10.13
-  - libxcrypt >=4.4.36
-  - ncurses >=6.5,<7.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 366207
-  timestamp: 1752068493156
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tcsh-6.24.10-h92ec313_0.conda
   sha256: 54a72e6b28d8703a157e3dbce9b6b2eed96eac4faf38ab3ef480eb4d3c827b9e
   md5: bcf531539d8c790785ae53762bd3ca83
@@ -19279,86 +18836,6 @@ packages:
   - pkg:pypi/xonsh?source=compressed-mapping
   size: 2117240
   timestamp: 1776799869014
-- conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.19.10-py310h2ec42d9_0.conda
-  sha256: 332a4deb094d0af53f793a2da211a674228da8605a63c878c18063042d40c349
-  md5: bc8b4eacb8a60adc57e93b9be2424239
-  depends:
-  - prompt_toolkit
-  - pygments >=2.2
-  - pyperclip
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - setproctitle
-  license: BSD-2-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/xonsh?source=hash-mapping
-  size: 1056672
-  timestamp: 1750799511531
-- conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py311h6eed73b_0.conda
-  sha256: d115f9b476d55b8ff131469b8c348435b8fd3371d40738cb91bb21a4379f0fec
-  md5: 29886df7a3c59b41ac11a8f3dd1b9e85
-  depends:
-  - prompt_toolkit
-  - pygments >=2.2
-  - pyperclip
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - setproctitle
-  license: BSD-2-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/xonsh?source=hash-mapping
-  size: 1508417
-  timestamp: 1776800396240
-- conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py312hb401068_0.conda
-  sha256: 2352ae562f9c374cb337d70cbc9ac4bf4f6cf5813fe9813b3f91111fba429636
-  md5: 9a4d419e762d76f071cc415260196dd9
-  depends:
-  - prompt_toolkit
-  - pygments >=2.2
-  - pyperclip
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - setproctitle
-  license: BSD-2-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/xonsh?source=hash-mapping
-  size: 1473882
-  timestamp: 1776800096959
-- conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py313habf4b1d_0.conda
-  sha256: a6ddffc946e490de8f5bd660a7dca4d29c0a6ee8b53bdce7adf573fc46db60da
-  md5: 44e78f3e870a14501da9c59b6968095e
-  depends:
-  - prompt_toolkit
-  - pygments >=2.2
-  - pyperclip
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - setproctitle
-  license: BSD-2-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/xonsh?source=hash-mapping
-  size: 1498500
-  timestamp: 1776800357842
-- conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py314hee6578b_0.conda
-  sha256: 5eecdf33e6fbc95b6ac870dd7e4ad3cd891bd567ebea917819b021e3812757dc
-  md5: c4e287ba0c03b76c88d74dab171899ed
-  depends:
-  - prompt_toolkit
-  - pygments >=2.2
-  - pyperclip
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  - setproctitle
-  license: BSD-2-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/xonsh?source=hash-mapping
-  size: 2130427
-  timestamp: 1776800392174
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xonsh-0.19.10-py310hbe9552e_0.conda
   sha256: f70817c023b5ffb4ec12d962ad67764ee0821b60cd92bee71074748cfbe2918f
   md5: 978888a446efd298df4cdaa88dff201e
@@ -19444,86 +18921,6 @@ packages:
   - pkg:pypi/xonsh?source=compressed-mapping
   size: 2083755
   timestamp: 1776800251248
-- conda: https://conda.anaconda.org/conda-forge/win-64/xonsh-0.19.10-py310h5588dad_0.conda
-  sha256: 120f23c69404abf875b06774a56ba44923483f7a2603cb1d93a7e11487c6d154
-  md5: 4b330c012e904065427b0c5b72281b68
-  depends:
-  - prompt_toolkit
-  - pygments >=2.2
-  - pyperclip
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - setproctitle
-  license: BSD-2-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/xonsh?source=hash-mapping
-  size: 1164711
-  timestamp: 1750799565512
-- conda: https://conda.anaconda.org/conda-forge/win-64/xonsh-0.23.1-py311h1ea47a8_0.conda
-  sha256: 05a65995b4a659ab34ab1379bc79db0bfd10fde4343dd04c6f88a5e00351f41b
-  md5: b45b86659ce9e62af95bc830896f060f
-  depends:
-  - prompt_toolkit
-  - pygments >=2.2
-  - pyperclip
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - setproctitle
-  license: BSD-2-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/xonsh?source=hash-mapping
-  size: 1616457
-  timestamp: 1776800068748
-- conda: https://conda.anaconda.org/conda-forge/win-64/xonsh-0.23.1-py312h2e8e312_0.conda
-  sha256: e2a95feb62a3aa75aed1f7065b1cc6fa652cc73592100805b07e92e1c7c1f3e0
-  md5: 62846931ff97677092b8b22245aa303c
-  depends:
-  - prompt_toolkit
-  - pygments >=2.2
-  - pyperclip
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - setproctitle
-  license: BSD-2-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/xonsh?source=hash-mapping
-  size: 1588770
-  timestamp: 1776800045488
-- conda: https://conda.anaconda.org/conda-forge/win-64/xonsh-0.23.1-py313hfa70ccb_0.conda
-  sha256: 6e07b1be7c569460729453078c443c19b6b714c0514ac40e7b8aa549891f3da3
-  md5: 1a55642f981bfeb3485f845b76801030
-  depends:
-  - prompt_toolkit
-  - pygments >=2.2
-  - pyperclip
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - setproctitle
-  license: BSD-2-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/xonsh?source=hash-mapping
-  size: 1610046
-  timestamp: 1776800059005
-- conda: https://conda.anaconda.org/conda-forge/win-64/xonsh-0.23.1-py314h86ab7b2_0.conda
-  sha256: d6ee2d8bd9b5d925c7a8c1a32d539c370fbd4a4388caa2d34e1dcf6dfd1e7874
-  md5: 1819cca578cd16685c20325be8667962
-  depends:
-  - prompt_toolkit
-  - pygments >=2.2
-  - pyperclip
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  - setproctitle
-  license: BSD-2-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/xonsh?source=compressed-mapping
-  size: 2258238
-  timestamp: 1776800046920
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
   sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
   md5: fb901ff28063514abb6046c9ec2c4a45

--- a/pixi.lock
+++ b/pixi.lock
@@ -1819,6 +1819,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fish-4.6.0-ha09e916_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-11.0.2-h3c5361c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.6-py310hb9d19b6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
@@ -1852,6 +1853,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsolv-0.7.30-h69d5d9b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.2-hdb6dae5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-h3dc7d44_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcrypt-4.4.36-h10d778d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.5-he8ee3e7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-17.0.6-hbedff68_1.conda
@@ -1866,18 +1868,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hc426f3f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/patch-2.7.6-hbcf498f_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.1-py310hbb8c376_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/py-lief-0.14.1-py310h53e7c6a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pycosat-0.6.6-py310hbb8c376_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.0-py310hae5a141_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.0-py310hae5a141_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.12.0-pyhd8ed1ab_0.conda
@@ -1895,6 +1904,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.22.3-py310h98870a7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.10-py310hbb8c376_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.8-py310hb9d19b6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py310h8bcfd8d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
@@ -1902,6 +1912,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.15.0-h0ec5880_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tcsh-6.24.16-h7768305_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
@@ -1910,6 +1921,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.0.1-py310hfa8da69_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.19.10-py310h2ec42d9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-he965462_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
@@ -2365,6 +2378,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fish-4.6.0-ha09e916_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-11.0.2-h3c5361c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.6-py311h1314207_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
@@ -2399,6 +2413,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsolv-0.7.30-h69d5d9b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.2-hdb6dae5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-h3dc7d44_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcrypt-4.4.36-h10d778d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.5-he8ee3e7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-17.0.6-hbedff68_1.conda
@@ -2413,18 +2428,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hc426f3f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/patch-2.7.6-hbcf498f_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.1-py311h4d7f069_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/py-lief-0.14.1-py311hd89902b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pycosat-0.6.6-py311h4d7f069_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.0-py311hfbc4093_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.0-py311hfbc4093_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.12.0-pyhd8ed1ab_0.conda
@@ -2442,6 +2464,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.22.3-py311h3b9c2be_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.10-py311h4d7f069_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.8-py311h1314207_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py311ha332486_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
@@ -2449,6 +2472,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.15.0-h0ec5880_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tcsh-6.24.16-h7768305_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
@@ -2457,6 +2481,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.0.1-py311hf2f7c97_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py311h6eed73b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-he965462_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
@@ -2914,6 +2940,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fish-4.6.0-ha09e916_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-11.0.2-h3c5361c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.6-py312h3d0f464_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
@@ -2948,6 +2975,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsolv-0.7.30-h69d5d9b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.2-hdb6dae5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-h3dc7d44_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcrypt-4.4.36-h10d778d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.5-he8ee3e7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-17.0.6-hbedff68_1.conda
@@ -2962,18 +2990,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hc426f3f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/patch-2.7.6-hbcf498f_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.1-py312h01d7ebd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/py-lief-0.14.1-py312h5861a67_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pycosat-0.6.6-py312h01d7ebd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.0-py312h2365019_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.0-py312h2365019_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.12.0-pyhd8ed1ab_0.conda
@@ -2991,6 +3026,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.22.3-py312h0d0de52_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.10-py312h01d7ebd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.8-py312h3d0f464_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py312hf7082af_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
@@ -2998,6 +3034,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.15.0-h0ec5880_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tcsh-6.24.16-h7768305_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
@@ -3006,6 +3043,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.0.1-py312hc5c4d5f_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py312hb401068_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-he965462_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
@@ -3472,6 +3511,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/evalidate-2.0.5-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fish-4.6.0-ha09e916_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-12.1.0-hda137b5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.7-py313hf050af9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
@@ -3510,6 +3550,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsolv-0.7.36-hf97c9bc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.0-h8f8c405_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-hed3591d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcrypt-4.4.36-h10d778d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
@@ -3527,11 +3568,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/patch-2.8-h8616949_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.2.2-py313h16366db_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/py-lief-0.17.6-py313hbc4457e_0.conda
@@ -3539,6 +3583,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pycosat-0.6.6-py313h585f44e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-12.1-py313h07bcf3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.1-py313hf669bc3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -3557,6 +3604,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.30.0-py313hcc225dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.17-py313h16366db_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.15-py313h16366db_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py313h16366db_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-codesign-0.1.3-hc0f2934_0.conda
@@ -3564,6 +3612,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.17.0-h30f01e4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1600.0.11.8-h8d8e812_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tcsh-6.24.16-h7768305_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
@@ -3574,6 +3623,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.1.0-py313h252b9d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.2.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py313habf4b1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-h92383a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
@@ -4056,6 +4107,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/evalidate-2.0.5-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fish-4.6.0-ha09e916_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-12.1.0-hda137b5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.7-py314h6482030_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
@@ -4094,6 +4146,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsolv-0.7.36-hf97c9bc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.0-h8f8c405_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-hed3591d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcrypt-4.4.36-h10d778d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
@@ -4111,11 +4164,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/patch-2.8-h8616949_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.2.2-py314hd330473_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/py-lief-0.17.6-py314h7008281_0.conda
@@ -4123,6 +4179,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pycosat-0.6.6-py314h03d016b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-12.1-py314h681fd4f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.1-py314h9720295_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -4141,6 +4200,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.30.0-py314ha7b6dee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.17-py314hd330473_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.15-py314hd330473_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py314hd330473_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-codesign-0.1.3-hc0f2934_0.conda
@@ -4148,6 +4208,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.17.0-h30f01e4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1600.0.11.8-h8d8e812_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tcsh-6.24.16-h7768305_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
@@ -4158,6 +4219,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.1.0-py314h473ef84_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.2.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py314hee6578b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-h92383a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
@@ -7512,8 +7575,8 @@ packages:
   timestamp: 1751548225624
 - pypi: ./
   name: conda-spawn
-  version: 0.0.6.dev20+gc0f3ae7e4.d20260424
-  sha256: 0402df1b6935d76e65b52c0a8f053326676556a363e702e16ed65fa877c2929c
+  version: 0.0.6.dev21+g4623cca67.d20260424
+  sha256: 8e98bb2ac2e8271cc97560c5b813fd3bb891efaabb8a0368fac8884625a3f85e
   requires_dist:
   - pexpect
   - shellingham
@@ -7726,6 +7789,20 @@ packages:
   purls: []
   size: 10832475
   timestamp: 1774679111989
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fish-4.6.0-ha09e916_0.conda
+  sha256: d0d33159bc5e08710646363c8cfc4aa9c3d03f8f5a36308a01a356a8112987e9
+  md5: d738fa29d86a810993fefec866978610
+  depends:
+  - __osx >=11.0
+  - ncurses >=6.5,<7.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  constrains:
+  - __osx >=10.13
+  license: GPL-2.0-only
+  license_family: GPL
+  purls: []
+  size: 10616294
+  timestamp: 1774679256083
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fish-4.6.0-h6f4fc28_0.conda
   sha256: 08ea663ecb5f60481b5798d48d179597e90102e35c41b73c4a74bb3d98b29df3
   md5: b672e875a12fca11231789278071a265
@@ -11282,6 +11359,13 @@ packages:
   purls: []
   size: 100393
   timestamp: 1702724383534
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxcrypt-4.4.36-h10d778d_1.conda
+  sha256: 7f438b1491326da20433b486efdbdfac3fe7b105676f44bcd4fb9a306a773b5c
+  md5: c4497a698d8b932569aff7e1c15765de
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 97816
+  timestamp: 1702724522480
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-h0d44e9d_1.conda
   sha256: 306e18aa647d8208ad2cd0e62d84933222b2fbe93d2d53cd5283d2256b1d54de
   md5: f5b05674697ae7d2c5932766695945e1
@@ -13153,6 +13237,18 @@ packages:
   purls: []
   size: 1222481
   timestamp: 1763655398280
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
+  sha256: 8d64a9d36073346542e5ea042ef8207a45a0069a2e65ce3323ee3146db78134c
+  md5: 08f970fb2b75f5be27678e077ebedd46
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1106584
+  timestamp: 1763655837207
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.47-h30297fc_0.conda
   sha256: 5e2e443f796f2fd92adf7978286a525fb768c34e12b1ee9ded4000a41b2894ba
   md5: 9b4190c4055435ca3502070186eba53a
@@ -14325,6 +14421,81 @@ packages:
   - pkg:pypi/pygments?source=compressed-mapping
   size: 893031
   timestamp: 1774796815820
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.0-py310hae5a141_0.conda
+  sha256: 5f2cf2f8ab52cbc6a4fdf52a8e60f142e8925a090ea2a7c207f37e275abed522
+  md5: 2bcbeb72c360a1f07c3719a0c40ab173
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - setuptools
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-core?source=hash-mapping
+  size: 440659
+  timestamp: 1736891377279
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.0-py311hfbc4093_0.conda
+  sha256: 7cc9dd5c836631c733173c88187231bfc0438135e0ddf94e866e45b3d10592bd
+  md5: 3b2f520d27fa7cf9c6c73fb43c69a321
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-core?source=hash-mapping
+  size: 489258
+  timestamp: 1736891091428
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.0-py312h2365019_0.conda
+  sha256: 91a27ede294fec129d115f2e0b0ce881f0c12332ee5e9c33ba522c037ad14bbb
+  md5: 0925c0e6ee32098c461423ea93490b97
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - setuptools
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-core?source=hash-mapping
+  size: 489634
+  timestamp: 1736891165910
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-12.1-py313h07bcf3a_0.conda
+  sha256: 1e0edd34b804e20ba064dcebcfce3066d841ec812f29ed65902da7192af617d1
+  md5: 6a2c3a617a70f97ca53b7b88461b1c27
+  depends:
+  - __osx >=10.13
+  - libffi >=3.5.2,<3.6.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - setuptools
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-core?source=hash-mapping
+  size: 491157
+  timestamp: 1763151415674
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-12.1-py314h681fd4f_0.conda
+  sha256: f95c247d52009fd29887904a3ca1556ffd6cf0bff225b63f914c7b294007100a
+  md5: eea444aa695378a47d13a974a31c893d
+  depends:
+  - __osx >=10.13
+  - libffi >=3.5.2,<3.6.0a0
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  - setuptools
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-core?source=hash-mapping
+  size: 491826
+  timestamp: 1763151541038
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.0-py310h4e4eb3c_0.conda
   sha256: ef1860dd429d8294d8d3c819e7f2f63b54095321c6a589f333d3ffe67d4d7857
   md5: 113f27b3a820a326335e11dca0a0a032
@@ -14405,6 +14576,81 @@ packages:
   - pkg:pypi/pyobjc-core?source=hash-mapping
   size: 483374
   timestamp: 1763151489724
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.0-py310hae5a141_0.conda
+  sha256: dcf0154027aaa49eebd6095457b45666ec8430ee0b9e701701f801a6944cc2ee
+  md5: d61b4a008a1fa7443c549520ce041a25
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 11.0.*
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
+  size: 337668
+  timestamp: 1736927235562
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.0-py311hfbc4093_0.conda
+  sha256: 94e00e4c9b5c5d8b2374321a0f908b7812b06ac8c9cb99242ddaa4ea0091f0be
+  md5: d16654f6b3f602bb0acab446c55bcafb
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 11.0.*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
+  size: 385111
+  timestamp: 1736927116099
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.0-py312h2365019_0.conda
+  sha256: 974fc6659f162a6e9cf201e5544f32d5c38d795a1141b327f87be2821dc7bf07
+  md5: 2486dd4f176f772531e0ecf22a8b85bd
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 11.0.*
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
+  size: 381786
+  timestamp: 1736927108218
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.1-py313hf669bc3_0.conda
+  sha256: 4761b8448bb9ecfcd9636a506104e6474e0f4cb73d108f2088997702ae984a00
+  md5: 628b5ad83d6140fe4bfa937e2f357ed7
+  depends:
+  - __osx >=10.13
+  - libffi >=3.5.2,<3.6.0a0
+  - pyobjc-core 12.1.*
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
+  size: 374120
+  timestamp: 1763160397755
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.1-py314h9720295_0.conda
+  sha256: b1a54bbe3223a919e33778ee70c74756305f7fd14b7e739f4df8d576783a78ca
+  md5: 992ab0e7362326773eb8c2afa5c28a71
+  depends:
+  - __osx >=10.13
+  - libffi >=3.5.2,<3.6.0a0
+  - pyobjc-core 12.1.*
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
+  size: 374960
+  timestamp: 1763160496034
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.0-py310h4e4eb3c_0.conda
   sha256: 2dbc1f27b4f131ee7ca7386f205d002cb45fb9919c3a042901b971e10aca33c6
   md5: 6fe7f5e5ac9c83f5d1942b5d96e4f9b3
@@ -17382,6 +17628,71 @@ packages:
   - pkg:pypi/setproctitle?source=hash-mapping
   size: 23438
   timestamp: 1766684440482
+- conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py310h8bcfd8d_0.conda
+  sha256: 9ab8401a1b0b6a7ccd3bec866ff13702bd5ac7ebec466608e20cde3e204b030f
+  md5: 487dbddb77a1041825e5f4d05c8bc793
+  depends:
+  - python
+  - __osx >=10.13
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 21585
+  timestamp: 1766684443530
+- conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py311ha332486_0.conda
+  sha256: 343ebd90baa78d976c0da4eba67001d7446c38543cd706182de2d8ee42ffb862
+  md5: 67b18b09998932da94cfe958697169c4
+  depends:
+  - python
+  - __osx >=10.13
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 21924
+  timestamp: 1766684439140
+- conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py312hf7082af_0.conda
+  sha256: 13b4a05e5554964b02e42fae309a619072a04e4f474a32c395f9470a957e7291
+  md5: 86753db84cac12fd00516d7dcfb7ac81
+  depends:
+  - python
+  - __osx >=10.13
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 21891
+  timestamp: 1766684445937
+- conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py313h16366db_0.conda
+  sha256: e0e0d6a04fc9680a081422723744cfd5a2844e46031492ead46697f624b7a14b
+  md5: 41cdd01b06386ef60b73c96d082793ea
+  depends:
+  - python
+  - __osx >=10.13
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 22021
+  timestamp: 1766684444946
+- conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py314hd330473_0.conda
+  sha256: e73e0e6208732bf69747c25ac9fe4d029cde3054569832da7e5e2c8832738aac
+  md5: b06b7a4d54691533591ce0a9c59d88b5
+  depends:
+  - python
+  - __osx >=10.13
+  - python_abi 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 22166
+  timestamp: 1766684437572
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/setproctitle-1.3.7-py310haea493c_0.conda
   sha256: 90dd3397e4db3e325838f6fefaa9481998534068d300f8eb0900e36603504b2e
   md5: 6abf3c8c9d18d356c4b3c9622b02768d
@@ -18003,6 +18314,18 @@ packages:
   purls: []
   size: 386085
   timestamp: 1752068404654
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tcsh-6.24.16-h7768305_0.conda
+  sha256: 77cc914f8c46439949f520e6386d9df5f3c7419bf3fe0c19b54ed2cd07b2717f
+  md5: 1a4cb84b92858150a1ecc6ffc7804b12
+  depends:
+  - __osx >=10.13
+  - libxcrypt >=4.4.36
+  - ncurses >=6.5,<7.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 366207
+  timestamp: 1752068493156
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tcsh-6.24.10-h92ec313_0.conda
   sha256: 54a72e6b28d8703a157e3dbce9b6b2eed96eac4faf38ab3ef480eb4d3c827b9e
   md5: bcf531539d8c790785ae53762bd3ca83
@@ -18836,6 +19159,86 @@ packages:
   - pkg:pypi/xonsh?source=compressed-mapping
   size: 2117240
   timestamp: 1776799869014
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.19.10-py310h2ec42d9_0.conda
+  sha256: 332a4deb094d0af53f793a2da211a674228da8605a63c878c18063042d40c349
+  md5: bc8b4eacb8a60adc57e93b9be2424239
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 1056672
+  timestamp: 1750799511531
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py311h6eed73b_0.conda
+  sha256: d115f9b476d55b8ff131469b8c348435b8fd3371d40738cb91bb21a4379f0fec
+  md5: 29886df7a3c59b41ac11a8f3dd1b9e85
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 1508417
+  timestamp: 1776800396240
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py312hb401068_0.conda
+  sha256: 2352ae562f9c374cb337d70cbc9ac4bf4f6cf5813fe9813b3f91111fba429636
+  md5: 9a4d419e762d76f071cc415260196dd9
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 1473882
+  timestamp: 1776800096959
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py313habf4b1d_0.conda
+  sha256: a6ddffc946e490de8f5bd660a7dca4d29c0a6ee8b53bdce7adf573fc46db60da
+  md5: 44e78f3e870a14501da9c59b6968095e
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 1498500
+  timestamp: 1776800357842
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py314hee6578b_0.conda
+  sha256: 5eecdf33e6fbc95b6ac870dd7e4ad3cd891bd567ebea917819b021e3812757dc
+  md5: c4e287ba0c03b76c88d74dab171899ed
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 2130427
+  timestamp: 1776800392174
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xonsh-0.19.10-py310hbe9552e_0.conda
   sha256: f70817c023b5ffb4ec12d962ad67764ee0821b60cd92bee71074748cfbe2918f
   md5: 978888a446efd298df4cdaa88dff201e

--- a/pixi.lock
+++ b/pixi.lock
@@ -1667,6 +1667,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fish-4.6.0-h5f5450b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.0.2-h434a139_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozendict-2.4.6-py310ha75aee5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
@@ -1705,6 +1706,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-h0d44e9d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
@@ -1720,18 +1722,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/patch-2.7.6-h7f98852_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/patchelf-0.17.2-h58526e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.1-py310ha75aee5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/py-lief-0.14.1-py310hf71b8c6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pycosat-0.6.6-py310ha75aee5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyha804496_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.12.0-pyhd8ed1ab_0.conda
@@ -1749,11 +1757,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.22.3-py310h505e2c1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.10-py310ha75aee5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.8-py310ha75aee5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/setproctitle-1.3.7-py310h139afa4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/simdjson-3.11.5-h84d6215_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.15.0-h10c9db5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tcsh-6.24.16-h18c060e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
@@ -1762,6 +1772,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py310h3788b33_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xclip-0.13-hb9d3cd8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xonsh-0.19.10-py310hff52083_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxmu-1.3.1-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xsel-1.2.1-hb9d3cd8_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-cpp-0.8.0-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
@@ -1797,6 +1819,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fish-4.6.0-ha09e916_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-11.0.2-h3c5361c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.6-py310hb9d19b6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
@@ -1830,6 +1853,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsolv-0.7.30-h69d5d9b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.2-hdb6dae5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-h3dc7d44_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcrypt-4.4.36-h10d778d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.5-he8ee3e7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-17.0.6-hbedff68_1.conda
@@ -1844,18 +1868,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hc426f3f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/patch-2.7.6-hbcf498f_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.1-py310hbb8c376_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/py-lief-0.14.1-py310h53e7c6a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pycosat-0.6.6-py310hbb8c376_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.0-py310hae5a141_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.0-py310hae5a141_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.12.0-pyhd8ed1ab_0.conda
@@ -1873,6 +1904,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.22.3-py310h98870a7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.10-py310hbb8c376_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.8-py310hb9d19b6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py310h8bcfd8d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
@@ -1880,6 +1912,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.15.0-h0ec5880_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tcsh-6.24.16-h7768305_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
@@ -1888,6 +1921,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.0.1-py310hfa8da69_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.19.10-py310h2ec42d9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-he965462_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
@@ -1923,6 +1958,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fish-4.6.0-h6f4fc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-11.0.2-h420ef59_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozendict-2.4.6-py310hf9df320_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
@@ -1972,18 +2008,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h81ee809_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/patch-2.7.6-h27ca646_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.47-h30297fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.1-py310h078409c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/py-lief-0.14.1-py310hb4ad77e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pycosat-0.6.6-py310h078409c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.0-py310h4e4eb3c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.0-py310h4e4eb3c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.12.0-pyhd8ed1ab_0.conda
@@ -2001,6 +2044,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.22.3-py310hde4708a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.10-py310h078409c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.8-py310hf9df320_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/setproctitle-1.3.7-py310haea493c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
@@ -2008,6 +2052,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.15.0-h096ffd4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tcsh-6.24.10-h92ec313_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
@@ -2016,6 +2061,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.0.1-py310h7306fd8_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xonsh-0.19.10-py310hbe9552e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-cpp-0.8.0-h13dd4ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
@@ -2094,12 +2141,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.1-py310ha8f682b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/py-lief-0.14.1-py310h9e98ed7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/pycosat-0.6.6-py310ha8f682b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.12.0-pyhd8ed1ab_0.conda
@@ -2116,6 +2167,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.22.3-py310hc226416_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.10-py310ha8f682b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.8-py310ha8f682b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/setproctitle-1.3.7-py310h1637853_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/simdjson-3.11.5-hc790b64_0.conda
@@ -2130,10 +2182,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/ukkonen-1.0.1-py310hc19bc0b_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_23.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-he29a5d6_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_34.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hdffcdeb_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.44.35208-h38c0c73_34.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xonsh-0.19.10-py310h5588dad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-cpp-0.8.0-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
@@ -2177,6 +2232,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fish-4.6.0-h5f5450b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.0.2-h434a139_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozendict-2.4.6-py311h9ecbd09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
@@ -2216,6 +2272,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-h0d44e9d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
@@ -2231,18 +2288,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/patch-2.7.6-h7f98852_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/patchelf-0.17.2-h58526e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.1-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/py-lief-0.14.1-py311hfdbb021_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pycosat-0.6.6-py311h9ecbd09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyha804496_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.12.0-pyhd8ed1ab_0.conda
@@ -2260,11 +2323,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.22.3-py311h9e33e62_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.10-py311h9ecbd09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.8-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/setproctitle-1.3.7-py311haee01d2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/simdjson-3.11.5-h84d6215_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.15.0-h10c9db5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tcsh-6.24.16-h18c060e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
@@ -2273,6 +2338,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py311hd18a35c_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xclip-0.13-hb9d3cd8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xonsh-0.23.1-py311h38be061_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxmu-1.3.1-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xsel-1.2.1-hb9d3cd8_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-cpp-0.8.0-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
@@ -2308,6 +2385,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fish-4.6.0-ha09e916_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-11.0.2-h3c5361c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.6-py311h1314207_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
@@ -2342,6 +2420,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsolv-0.7.30-h69d5d9b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.2-hdb6dae5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-h3dc7d44_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcrypt-4.4.36-h10d778d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.5-he8ee3e7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-17.0.6-hbedff68_1.conda
@@ -2356,18 +2435,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hc426f3f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/patch-2.7.6-hbcf498f_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.1-py311h4d7f069_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/py-lief-0.14.1-py311hd89902b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pycosat-0.6.6-py311h4d7f069_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.0-py311hfbc4093_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.0-py311hfbc4093_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.12.0-pyhd8ed1ab_0.conda
@@ -2385,6 +2471,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.22.3-py311h3b9c2be_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.10-py311h4d7f069_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.8-py311h1314207_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py311ha332486_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
@@ -2392,6 +2479,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.15.0-h0ec5880_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tcsh-6.24.16-h7768305_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
@@ -2400,6 +2488,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.0.1-py311hf2f7c97_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py311h6eed73b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-he965462_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
@@ -2435,6 +2525,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fish-4.6.0-h6f4fc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-11.0.2-h420ef59_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozendict-2.4.6-py311hae2e1ce_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
@@ -2485,18 +2576,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h81ee809_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/patch-2.7.6-h27ca646_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.47-h30297fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.1-py311h917b07b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/py-lief-0.14.1-py311h3f08180_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pycosat-0.6.6-py311h917b07b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.0-py311hab620ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.0-py311hab620ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.12.0-pyhd8ed1ab_0.conda
@@ -2514,6 +2612,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.22.3-py311h3ff9189_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.10-py311h917b07b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.8-py311hae2e1ce_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/setproctitle-1.3.7-py311he363849_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
@@ -2521,6 +2620,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.15.0-h096ffd4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tcsh-6.24.10-h92ec313_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
@@ -2529,6 +2629,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.0.1-py311h2c37856_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xonsh-0.23.1-py311h267d04e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-cpp-0.8.0-h13dd4ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
@@ -2608,12 +2710,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.1-py311he736701_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/py-lief-0.14.1-py311hda3d55a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/pycosat-0.6.6-py311he736701_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.12.0-pyhd8ed1ab_0.conda
@@ -2630,6 +2736,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.22.3-py311h533ab2d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.10-py311he736701_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.8-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/setproctitle-1.3.7-py311hf893f09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/simdjson-3.11.5-hc790b64_0.conda
@@ -2644,10 +2751,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/ukkonen-1.0.1-py311h3257749_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_23.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-he29a5d6_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_34.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hdffcdeb_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.44.35208-h38c0c73_34.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xonsh-0.23.1-py311h1ea47a8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-cpp-0.8.0-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
@@ -2691,6 +2801,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fish-4.6.0-h5f5450b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.0.2-h434a139_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozendict-2.4.6-py312h66e93f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
@@ -2730,6 +2841,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-h0d44e9d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
@@ -2745,18 +2857,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/patch-2.7.6-h7f98852_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/patchelf-0.17.2-h58526e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.1-py312h66e93f0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/py-lief-0.14.1-py312h2ec8cdc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pycosat-0.6.6-py312h66e93f0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyha804496_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.12.0-pyhd8ed1ab_0.conda
@@ -2774,11 +2892,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.22.3-py312h12e396e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.10-py312h66e93f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.8-py312h66e93f0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/setproctitle-1.3.7-py312h5253ce2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/simdjson-3.11.5-h84d6215_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.15.0-h10c9db5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tcsh-6.24.16-h18c060e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
@@ -2787,6 +2907,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py312h68727a3_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xclip-0.13-hb9d3cd8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xonsh-0.23.1-py312h7900ff3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxmu-1.3.1-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xsel-1.2.1-hb9d3cd8_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-cpp-0.8.0-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
@@ -2822,6 +2954,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fish-4.6.0-ha09e916_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-11.0.2-h3c5361c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.6-py312h3d0f464_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
@@ -2856,6 +2989,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsolv-0.7.30-h69d5d9b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.2-hdb6dae5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-h3dc7d44_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcrypt-4.4.36-h10d778d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.5-he8ee3e7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-17.0.6-hbedff68_1.conda
@@ -2870,18 +3004,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hc426f3f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/patch-2.7.6-hbcf498f_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.1-py312h01d7ebd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/py-lief-0.14.1-py312h5861a67_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pycosat-0.6.6-py312h01d7ebd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.0-py312h2365019_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.0-py312h2365019_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.12.0-pyhd8ed1ab_0.conda
@@ -2899,6 +3040,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.22.3-py312h0d0de52_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.10-py312h01d7ebd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.8-py312h3d0f464_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py312hf7082af_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
@@ -2906,6 +3048,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.15.0-h0ec5880_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tcsh-6.24.16-h7768305_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
@@ -2914,6 +3057,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.0.1-py312hc5c4d5f_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py312hb401068_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-he965462_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
@@ -2949,6 +3094,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fish-4.6.0-h6f4fc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-11.0.2-h420ef59_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozendict-2.4.6-py312h0bf5046_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
@@ -2999,18 +3145,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h81ee809_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/patch-2.7.6-h27ca646_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.47-h30297fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.1-py312hea69d52_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/py-lief-0.14.1-py312hde4cb15_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pycosat-0.6.6-py312hea69d52_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.0-py312hb9d441b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.0-py312hb9d441b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.12.0-pyhd8ed1ab_0.conda
@@ -3028,6 +3181,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.22.3-py312hcd83bfe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.10-py312hea69d52_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.8-py312h0bf5046_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/setproctitle-1.3.7-py312hb3ab3e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
@@ -3035,6 +3189,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.15.0-h096ffd4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tcsh-6.24.10-h92ec313_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
@@ -3043,6 +3198,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.0.1-py312h6142ec9_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xonsh-0.23.1-py312h81bd7bf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-cpp-0.8.0-h13dd4ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
@@ -3122,12 +3279,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.1-py312h4389bb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/py-lief-0.14.1-py312h275cf98_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/pycosat-0.6.6-py312h4389bb4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.12.0-pyhd8ed1ab_0.conda
@@ -3144,6 +3305,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.22.3-py312h2615798_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.10-py312h4389bb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.8-py312h4389bb4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/setproctitle-1.3.7-py312he5662c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/simdjson-3.11.5-hc790b64_0.conda
@@ -3158,10 +3320,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/ukkonen-1.0.1-py312hd5eb7cc_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_23.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-he29a5d6_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_34.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hdffcdeb_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.44.35208-h38c0c73_34.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xonsh-0.23.1-py312h2e8e312_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-cpp-0.8.0-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
@@ -3206,6 +3371,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/evalidate-2.0.5-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fish-4.6.0-h5f5450b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-12.1.0-hff5e90c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozendict-2.4.7-py313h07c4f96_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
@@ -3247,6 +3413,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
@@ -3263,18 +3431,23 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/patch-2.8-hb03c661_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/patchelf-0.17.2-h58526e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py313h54dd161_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/py-lief-0.17.6-py313h7033f15_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pycosat-0.6.6-py313h07c4f96_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyha804496_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -3293,11 +3466,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py313h843e2db_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.17-py313h54dd161_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py313h54dd161_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/setproctitle-1.3.7-py313h54dd161_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/simdjson-4.2.4-hb700be7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.17.0-hab81395_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tcsh-6.24.16-h18c060e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
@@ -3308,6 +3483,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py313h7037e92_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.2.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xclip-0.13-hb9d3cd8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xonsh-0.23.1-py313h78bf25f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxmu-1.3.1-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xsel-1.2.1-hb9d3cd8_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-cpp-0.8.0-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
@@ -3345,6 +3532,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/evalidate-2.0.5-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fish-4.6.0-ha09e916_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-12.1.0-hda137b5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.7-py313hf050af9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
@@ -3383,6 +3571,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsolv-0.7.36-hf97c9bc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.0-h8f8c405_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-hed3591d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcrypt-4.4.36-h10d778d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
@@ -3400,11 +3589,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/patch-2.8-h8616949_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.2.2-py313h16366db_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/py-lief-0.17.6-py313hbc4457e_0.conda
@@ -3412,6 +3604,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pycosat-0.6.6-py313h585f44e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-12.1-py313h07bcf3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.1-py313hf669bc3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -3430,6 +3625,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.30.0-py313hcc225dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.17-py313h16366db_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.15-py313h16366db_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py313h16366db_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-codesign-0.1.3-hc0f2934_0.conda
@@ -3437,6 +3633,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.17.0-h30f01e4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1600.0.11.8-h8d8e812_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tcsh-6.24.16-h7768305_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
@@ -3447,6 +3644,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.1.0-py313h252b9d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.2.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py313habf4b1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-h92383a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
@@ -3484,6 +3683,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/evalidate-2.0.5-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fish-4.6.0-h6f4fc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-12.1.0-h403dcb5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozendict-2.4.7-py313h6535dbc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
@@ -3538,11 +3738,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/patch-2.8-hc919400_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.47-h30297fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py313h6688731_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/py-lief-0.17.5-py313h6deaedc_0.conda
@@ -3550,6 +3753,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pycosat-0.6.6-py313hcdf3177_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-12.1-py313h40b429f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-12.1-py313hcc5defa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -3568,6 +3774,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.30.0-py313h2c089d5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.17-py313h6688731_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py313h6688731_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/setproctitle-1.3.7-py313h6688731_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-codesign-0.1.3-h98dc951_0.conda
@@ -3575,6 +3782,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.17.0-ha0f8610_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1600.0.11.8-h997e182_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tcsh-6.24.10-h92ec313_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
@@ -3585,6 +3793,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.1.0-py313h5c29297_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.2.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xonsh-0.23.1-py313h8f79df9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-cpp-0.8.0-ha1acc90_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
@@ -3669,6 +3879,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.2.2-py313h5fd188c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/py-lief-0.17.6-py313hfe59770_0.conda
@@ -3676,6 +3888,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pycosat-0.6.6-py313h5ea7bf4_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -3693,6 +3906,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.30.0-py313hfbe8231_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.17-py313h5fd188c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py313h5fd188c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/setproctitle-1.3.7-py313h5fd188c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/simdjson-4.2.4-h49e36cd_0.conda
@@ -3712,7 +3926,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.2.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xonsh-0.23.1-py313hfa70ccb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-cpp-0.8.0-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
@@ -3757,6 +3973,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/evalidate-2.0.5-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fish-4.6.0-h5f5450b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-12.1.0-hff5e90c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozendict-2.4.7-py314h5bd0f2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
@@ -3798,6 +4015,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
@@ -3814,18 +4033,23 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/patch-2.8-hb03c661_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/patchelf-0.17.2-h58526e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py314h0f05182_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/py-lief-0.17.6-py314ha160325_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pycosat-0.6.6-py314h5bd0f2a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyha804496_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -3844,11 +4068,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py314h2e6c369_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.17-py314h0f05182_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py314h0f05182_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/setproctitle-1.3.7-py314h0f05182_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/simdjson-4.2.4-hb700be7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.17.0-hab81395_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tcsh-6.24.16-h18c060e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
@@ -3859,6 +4085,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py314h9891dd4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.2.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xclip-0.13-hb9d3cd8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xonsh-0.23.1-py314hdafbbf9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxmu-1.3.1-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xsel-1.2.1-hb9d3cd8_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-cpp-0.8.0-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
@@ -3896,6 +4134,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/evalidate-2.0.5-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fish-4.6.0-ha09e916_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-12.1.0-hda137b5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.7-py314h6482030_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
@@ -3934,6 +4173,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsolv-0.7.36-hf97c9bc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.0-h8f8c405_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-hed3591d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcrypt-4.4.36-h10d778d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
@@ -3951,11 +4191,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/patch-2.8-h8616949_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.2.2-py314hd330473_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/py-lief-0.17.6-py314h7008281_0.conda
@@ -3963,6 +4206,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pycosat-0.6.6-py314h03d016b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-12.1-py314h681fd4f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.1-py314h9720295_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -3981,6 +4227,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.30.0-py314ha7b6dee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.17-py314hd330473_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.15-py314hd330473_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py314hd330473_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-codesign-0.1.3-hc0f2934_0.conda
@@ -3988,6 +4235,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.17.0-h30f01e4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1600.0.11.8-h8d8e812_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tcsh-6.24.16-h7768305_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
@@ -3998,6 +4246,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.1.0-py314h473ef84_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.2.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py314hee6578b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-h92383a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
@@ -4035,6 +4285,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/evalidate-2.0.5-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fish-4.6.0-h6f4fc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-12.1.0-h403dcb5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozendict-2.4.7-py314h0612a62_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
@@ -4089,11 +4340,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/patch-2.8-hc919400_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.47-h30297fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py314ha14b1ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/py-lief-0.17.5-py314h4ed92d5_0.conda
@@ -4101,6 +4355,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pycosat-0.6.6-py314hb84d1df_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-12.1-py314h3a4d195_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-12.1-py314h36abed7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -4119,6 +4376,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.30.0-py314haad56a0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.17-py314ha14b1ff_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py314ha14b1ff_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/setproctitle-1.3.7-py314ha14b1ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-codesign-0.1.3-h98dc951_0.conda
@@ -4126,6 +4384,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.17.0-ha0f8610_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1600.0.11.8-h997e182_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tcsh-6.24.10-h92ec313_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
@@ -4136,6 +4395,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.1.0-py314h6cfcd04_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.2.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xonsh-0.23.1-py314h4dc9dd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-cpp-0.8.0-ha1acc90_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
@@ -4220,6 +4481,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.2.2-py314hc5dbbe4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/py-lief-0.17.6-py314h13fbf68_0.conda
@@ -4227,6 +4490,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pycosat-0.6.6-py314h5a2d7ad_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -4244,6 +4508,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.30.0-py314h9f07db2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.17-py314hc5dbbe4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py314hc5dbbe4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/setproctitle-1.3.7-py314hc5dbbe4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/simdjson-4.2.4-h49e36cd_0.conda
@@ -4263,7 +4528,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.2.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xonsh-0.23.1-py314h86ab7b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-cpp-0.8.0-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
@@ -7341,8 +7608,8 @@ packages:
   timestamp: 1751548225624
 - pypi: ./
   name: conda-spawn
-  version: 0.0.6.dev14+g82d3939b6.d20260423
-  sha256: 633dfa91763122ee7a9916fbc0db8885a81286fd1a9a2eb7918c26cb889ebd45
+  version: 0.0.6.dev18+g177a5ba80.d20260424
+  sha256: 565055247d30f3d125d315f8b94039ac6859322112e9bf7ee7095db493c24b08
   requires_dist:
   - pexpect
   - shellingham
@@ -7540,6 +7807,49 @@ packages:
   - pkg:pypi/filelock?source=compressed-mapping
   size: 34211
   timestamp: 1776621506566
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fish-4.6.0-h5f5450b_0.conda
+  sha256: c189371acefe2ceadcfe8bb1207592e14279bbb2041bca5ded38d6a099a0527e
+  md5: dc1c21bfd5e97f0c11906fab129f15ff
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ncurses >=6.5,<7.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  constrains:
+  - __glibc >=2.17
+  license: GPL-2.0-only
+  license_family: GPL
+  purls: []
+  size: 10832475
+  timestamp: 1774679111989
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fish-4.6.0-ha09e916_0.conda
+  sha256: d0d33159bc5e08710646363c8cfc4aa9c3d03f8f5a36308a01a356a8112987e9
+  md5: d738fa29d86a810993fefec866978610
+  depends:
+  - __osx >=11.0
+  - ncurses >=6.5,<7.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  constrains:
+  - __osx >=10.13
+  license: GPL-2.0-only
+  license_family: GPL
+  purls: []
+  size: 10616294
+  timestamp: 1774679256083
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fish-4.6.0-h6f4fc28_0.conda
+  sha256: 08ea663ecb5f60481b5798d48d179597e90102e35c41b73c4a74bb3d98b29df3
+  md5: b672e875a12fca11231789278071a265
+  depends:
+  - __osx >=11.0
+  - ncurses >=6.5,<7.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  constrains:
+  - __osx >=11.0
+  license: GPL-2.0-only
+  license_family: GPL
+  purls: []
+  size: 10255140
+  timestamp: 1774679304518
 - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.0.2-h434a139_0.conda
   sha256: c620e2ab084948985ae9b8848d841f603e8055655513340e04b6cf129099b5ca
   md5: 995f7e13598497691c1dc476d889bc04
@@ -11059,6 +11369,20 @@ packages:
   purls: []
   size: 40297
   timestamp: 1775052476770
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+  md5: 92ed62436b625154323d40d5f2f11dd7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 395888
+  timestamp: 1727278577118
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
   sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
   md5: 5aa797f8787fe7a17d1b0821485b5adc
@@ -11068,6 +11392,13 @@ packages:
   purls: []
   size: 100393
   timestamp: 1702724383534
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxcrypt-4.4.36-h10d778d_1.conda
+  sha256: 7f438b1491326da20433b486efdbdfac3fe7b105676f44bcd4fb9a306a773b5c
+  md5: c4497a698d8b932569aff7e1c15765de
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 97816
+  timestamp: 1702724522480
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-h0d44e9d_1.conda
   sha256: 306e18aa647d8208ad2cd0e62d84933222b2fbe93d2d53cd5283d2256b1d54de
   md5: f5b05674697ae7d2c5932766695945e1
@@ -12926,6 +13257,43 @@ packages:
   purls: []
   size: 94048
   timestamp: 1673473024463
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+  sha256: 5e6f7d161356fefd981948bea5139c5aa0436767751a6930cb1ca801ebb113ff
+  md5: 7a3bff861a6583f1889021facefc08b1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1222481
+  timestamp: 1763655398280
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
+  sha256: 8d64a9d36073346542e5ea042ef8207a45a0069a2e65ce3323ee3146db78134c
+  md5: 08f970fb2b75f5be27678e077ebedd46
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1106584
+  timestamp: 1763655837207
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.47-h30297fc_0.conda
+  sha256: 5e2e443f796f2fd92adf7978286a525fb768c34e12b1ee9ded4000a41b2894ba
+  md5: 9b4190c4055435ca3502070186eba53a
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 850231
+  timestamp: 1763655726735
 - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
   sha256: 202af1de83b585d36445dc1fda94266697341994d1a3328fabde4989e1b3d07a
   md5: d0d408b1f18883a944376da5cf8101ea
@@ -13047,6 +13415,30 @@ packages:
   - pkg:pypi/pre-commit?source=compressed-mapping
   size: 201606
   timestamp: 1776858157327
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+  sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
+  md5: edb16f14d920fb3faf17f5ce582942d6
+  depends:
+  - python >=3.10
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.52
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/prompt-toolkit?source=hash-mapping
+  size: 273927
+  timestamp: 1756321848365
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
+  sha256: e79922a360d7e620df978417dd033e66226e809961c3e659a193f978a75a9b0b
+  md5: 6d034d3a6093adbba7b24cb69c8c621e
+  depends:
+  - prompt-toolkit >=3.0.52,<3.0.53.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 7212
+  timestamp: 1756321849562
 - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.1-py310ha75aee5_0.conda
   sha256: a643a57e5338fb3a154c5d57fdc72d80170cf7868f20acbbeedde014195f0d92
   md5: 00838ea1d4e87b1e6e2552bba98cc899
@@ -13327,6 +13719,17 @@ packages:
   - pkg:pypi/psutil?source=hash-mapping
   size: 249950
   timestamp: 1769678167309
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+  sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+  md5: b3c17d95b5a10c6e64a21fa17573e70e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 8252
+  timestamp: 1726802366959
 - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
   sha256: a7713dfe30faf17508ec359e0bc7e0983f5d94682492469bd462cdaae9c64d83
   md5: 7d9daffbb8d8e0af0f769dbbcd173a54
@@ -14051,6 +14454,355 @@ packages:
   - pkg:pypi/pygments?source=compressed-mapping
   size: 893031
   timestamp: 1774796815820
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.0-py310hae5a141_0.conda
+  sha256: 5f2cf2f8ab52cbc6a4fdf52a8e60f142e8925a090ea2a7c207f37e275abed522
+  md5: 2bcbeb72c360a1f07c3719a0c40ab173
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - setuptools
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-core?source=hash-mapping
+  size: 440659
+  timestamp: 1736891377279
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.0-py311hfbc4093_0.conda
+  sha256: 7cc9dd5c836631c733173c88187231bfc0438135e0ddf94e866e45b3d10592bd
+  md5: 3b2f520d27fa7cf9c6c73fb43c69a321
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-core?source=hash-mapping
+  size: 489258
+  timestamp: 1736891091428
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.0-py312h2365019_0.conda
+  sha256: 91a27ede294fec129d115f2e0b0ce881f0c12332ee5e9c33ba522c037ad14bbb
+  md5: 0925c0e6ee32098c461423ea93490b97
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - setuptools
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-core?source=hash-mapping
+  size: 489634
+  timestamp: 1736891165910
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-12.1-py313h07bcf3a_0.conda
+  sha256: 1e0edd34b804e20ba064dcebcfce3066d841ec812f29ed65902da7192af617d1
+  md5: 6a2c3a617a70f97ca53b7b88461b1c27
+  depends:
+  - __osx >=10.13
+  - libffi >=3.5.2,<3.6.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - setuptools
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-core?source=hash-mapping
+  size: 491157
+  timestamp: 1763151415674
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-12.1-py314h681fd4f_0.conda
+  sha256: f95c247d52009fd29887904a3ca1556ffd6cf0bff225b63f914c7b294007100a
+  md5: eea444aa695378a47d13a974a31c893d
+  depends:
+  - __osx >=10.13
+  - libffi >=3.5.2,<3.6.0a0
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  - setuptools
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-core?source=hash-mapping
+  size: 491826
+  timestamp: 1763151541038
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.0-py310h4e4eb3c_0.conda
+  sha256: ef1860dd429d8294d8d3c819e7f2f63b54095321c6a589f333d3ffe67d4d7857
+  md5: 113f27b3a820a326335e11dca0a0a032
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - setuptools
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-core?source=hash-mapping
+  size: 431491
+  timestamp: 1736891197711
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.0-py311hab620ed_0.conda
+  sha256: 7eb9c40a460ea769f024aaf45dae9fde7ca41137ca82154c50c8aead8a32ff88
+  md5: cc865b09e7a02328840b163fb8856731
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-core?source=hash-mapping
+  size: 480994
+  timestamp: 1736891387770
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.0-py312hb9d441b_0.conda
+  sha256: 7805d910dd6ac686e2f780c879a986f35d7a4c73f4236c956c03bdcb26bec421
+  md5: 0726db04477a28c51d1a260afb356b67
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - setuptools
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-core?source=hash-mapping
+  size: 478921
+  timestamp: 1736891272846
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-12.1-py313h40b429f_0.conda
+  sha256: 307ca29ebf2317bd2561639b1ee0290fd8c03c3450fa302b9f9437d8df6a5280
+  md5: 31a0a72f3466682d0ea2ebcbd7d319b8
+  depends:
+  - __osx >=11.0
+  - libffi >=3.5.2,<3.6.0a0
+  - python >=3.13,<3.14.0a0
+  - python >=3.13,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  - setuptools
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-core?source=hash-mapping
+  size: 481508
+  timestamp: 1763152124940
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-12.1-py314h3a4d195_0.conda
+  sha256: df5af268c5a74b7160d772c263ece6f43257faff571783443e34b5f1d5a61cf2
+  md5: 75a84fc8337557347252cc4fd3ba2a93
+  depends:
+  - __osx >=11.0
+  - libffi >=3.5.2,<3.6.0a0
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  - setuptools
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-core?source=hash-mapping
+  size: 483374
+  timestamp: 1763151489724
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.0-py310hae5a141_0.conda
+  sha256: dcf0154027aaa49eebd6095457b45666ec8430ee0b9e701701f801a6944cc2ee
+  md5: d61b4a008a1fa7443c549520ce041a25
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 11.0.*
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
+  size: 337668
+  timestamp: 1736927235562
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.0-py311hfbc4093_0.conda
+  sha256: 94e00e4c9b5c5d8b2374321a0f908b7812b06ac8c9cb99242ddaa4ea0091f0be
+  md5: d16654f6b3f602bb0acab446c55bcafb
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 11.0.*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
+  size: 385111
+  timestamp: 1736927116099
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.0-py312h2365019_0.conda
+  sha256: 974fc6659f162a6e9cf201e5544f32d5c38d795a1141b327f87be2821dc7bf07
+  md5: 2486dd4f176f772531e0ecf22a8b85bd
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 11.0.*
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
+  size: 381786
+  timestamp: 1736927108218
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.1-py313hf669bc3_0.conda
+  sha256: 4761b8448bb9ecfcd9636a506104e6474e0f4cb73d108f2088997702ae984a00
+  md5: 628b5ad83d6140fe4bfa937e2f357ed7
+  depends:
+  - __osx >=10.13
+  - libffi >=3.5.2,<3.6.0a0
+  - pyobjc-core 12.1.*
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
+  size: 374120
+  timestamp: 1763160397755
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.1-py314h9720295_0.conda
+  sha256: b1a54bbe3223a919e33778ee70c74756305f7fd14b7e739f4df8d576783a78ca
+  md5: 992ab0e7362326773eb8c2afa5c28a71
+  depends:
+  - __osx >=10.13
+  - libffi >=3.5.2,<3.6.0a0
+  - pyobjc-core 12.1.*
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
+  size: 374960
+  timestamp: 1763160496034
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.0-py310h4e4eb3c_0.conda
+  sha256: 2dbc1f27b4f131ee7ca7386f205d002cb45fb9919c3a042901b971e10aca33c6
+  md5: 6fe7f5e5ac9c83f5d1942b5d96e4f9b3
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 11.0.*
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
+  size: 340886
+  timestamp: 1736927224726
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.0-py311hab620ed_0.conda
+  sha256: 33635759c626103696963a4d439f01cc534fe94c318ce5a14c7b9ddbe8dfb78c
+  md5: 39da4013010bd559600f775ebf6a5915
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 11.0.*
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
+  size: 389214
+  timestamp: 1736927161972
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.0-py312hb9d441b_0.conda
+  sha256: 53d099865f8f758029708f4365ee7c9184d9ffcc8fc8210971b723a3936f9c00
+  md5: dc263e6e18b32318a43252dbb0596ad4
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 11.0.*
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
+  size: 383608
+  timestamp: 1736927118445
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-12.1-py313hcc5defa_0.conda
+  sha256: 194e188d8119befc952d04157079733e2041a7a502d50340ddde632658799fdc
+  md5: a6d28c8fc266a3d3c3dae183e25c4d31
+  depends:
+  - __osx >=11.0
+  - libffi >=3.5.2,<3.6.0a0
+  - pyobjc-core 12.1.*
+  - python >=3.13,<3.14.0a0
+  - python >=3.13,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
+  size: 376136
+  timestamp: 1763160678792
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-12.1-py314h36abed7_0.conda
+  sha256: aa76ee4328d0514d7c1c455dcd2d3b547db1c59797e54ce0a3f27de5b970e508
+  md5: 4219bb3408016e22316cf8b443b5ef93
+  depends:
+  - __osx >=11.0
+  - libffi >=3.5.2,<3.6.0a0
+  - pyobjc-core 12.1.*
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
+  size: 374792
+  timestamp: 1763160601898
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh534df25_0.conda
+  sha256: 7d9a47bb6b7a884218340f9aeb5976e566ae1d9b6fdee0e532e8bc5061226a7f
+  md5: 613e9b6eb949baf115bc4a978b903e9d
+  depends:
+  - __osx
+  - pyobjc-framework-cocoa
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pyperclip?source=hash-mapping
+  size: 17000
+  timestamp: 1758906964482
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyh7428d3b_0.conda
+  sha256: 4c45cfde1f904a8b85450bb9803391dc4f2d658ecbdafa2313289e2dc3c8480a
+  md5: 66b53fbb78773cd282164fcf08878957
+  depends:
+  - __win
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pyperclip?source=hash-mapping
+  size: 17362
+  timestamp: 1758906942340
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.11.0-pyha804496_0.conda
+  sha256: 977fa57882322d2ed29ad54bc0084d79c27fde57f150be39923f2c0824fc3205
+  md5: 2054f5088a57280a8ea79df3d5341728
+  depends:
+  - __linux
+  - python >=3.10
+  - xclip
+  - xsel
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pyperclip?source=hash-mapping
+  size: 16983
+  timestamp: 1758906797105
 - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
   sha256: d016e04b0e12063fbee4a2d5fbb9b39a8d191b5a0042f0b8459188aedeabb0ca
   md5: e2fd202833c4a981ce8a65974fe4abd1
@@ -16851,6 +17603,286 @@ packages:
   - pkg:pypi/ruamel-yaml-clib?source=hash-mapping
   size: 108926
   timestamp: 1728725024979
+- conda: https://conda.anaconda.org/conda-forge/linux-64/setproctitle-1.3.7-py310h139afa4_0.conda
+  sha256: 80fc00acbfeaa052f88597c096ebb01c862a3b9e09bffee3137c6804e59698ba
+  md5: 9b46695dda92c124a67b396e3cfce0f0
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 23157
+  timestamp: 1766684434552
+- conda: https://conda.anaconda.org/conda-forge/linux-64/setproctitle-1.3.7-py311haee01d2_0.conda
+  sha256: 956addcef4f73ad997595e272c812738c69ede206a918b259b536596612520f7
+  md5: 274c968f55205db0b19b7034b6b7f088
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 23492
+  timestamp: 1766684457137
+- conda: https://conda.anaconda.org/conda-forge/linux-64/setproctitle-1.3.7-py312h5253ce2_0.conda
+  sha256: fc59372c21248cae366452d0901d946c55aac00b1d3a5b260001d48593fc2c9f
+  md5: bed00a090df33c7ba0db3d09f2e4293c
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 23575
+  timestamp: 1766684430348
+- conda: https://conda.anaconda.org/conda-forge/linux-64/setproctitle-1.3.7-py313h54dd161_0.conda
+  sha256: 3d5d8e3e98b32761590161e953cc050dc111820327e224616054f6a83c72aae6
+  md5: e03e4d5f3ae3e5067ecf1d33287d794c
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 23312
+  timestamp: 1766684440980
+- conda: https://conda.anaconda.org/conda-forge/linux-64/setproctitle-1.3.7-py314h0f05182_0.conda
+  sha256: 815c40cd99e76cfa0763167478b5b12d2934113283fd3a1dc67343a8e83a7ca6
+  md5: 431141f712fc1e7f69b9a666db5cc7d1
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 23438
+  timestamp: 1766684440482
+- conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py310h8bcfd8d_0.conda
+  sha256: 9ab8401a1b0b6a7ccd3bec866ff13702bd5ac7ebec466608e20cde3e204b030f
+  md5: 487dbddb77a1041825e5f4d05c8bc793
+  depends:
+  - python
+  - __osx >=10.13
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 21585
+  timestamp: 1766684443530
+- conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py311ha332486_0.conda
+  sha256: 343ebd90baa78d976c0da4eba67001d7446c38543cd706182de2d8ee42ffb862
+  md5: 67b18b09998932da94cfe958697169c4
+  depends:
+  - python
+  - __osx >=10.13
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 21924
+  timestamp: 1766684439140
+- conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py312hf7082af_0.conda
+  sha256: 13b4a05e5554964b02e42fae309a619072a04e4f474a32c395f9470a957e7291
+  md5: 86753db84cac12fd00516d7dcfb7ac81
+  depends:
+  - python
+  - __osx >=10.13
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 21891
+  timestamp: 1766684445937
+- conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py313h16366db_0.conda
+  sha256: e0e0d6a04fc9680a081422723744cfd5a2844e46031492ead46697f624b7a14b
+  md5: 41cdd01b06386ef60b73c96d082793ea
+  depends:
+  - python
+  - __osx >=10.13
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 22021
+  timestamp: 1766684444946
+- conda: https://conda.anaconda.org/conda-forge/osx-64/setproctitle-1.3.7-py314hd330473_0.conda
+  sha256: e73e0e6208732bf69747c25ac9fe4d029cde3054569832da7e5e2c8832738aac
+  md5: b06b7a4d54691533591ce0a9c59d88b5
+  depends:
+  - python
+  - __osx >=10.13
+  - python_abi 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 22166
+  timestamp: 1766684437572
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/setproctitle-1.3.7-py310haea493c_0.conda
+  sha256: 90dd3397e4db3e325838f6fefaa9481998534068d300f8eb0900e36603504b2e
+  md5: 6abf3c8c9d18d356c4b3c9622b02768d
+  depends:
+  - python
+  - python 3.10.* *_cpython
+  - __osx >=11.0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 24078
+  timestamp: 1766684440649
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/setproctitle-1.3.7-py311he363849_0.conda
+  sha256: bbcd7f7519a08fa270d8915bcfb34fd5a735c1a92f0c6da1dc60006e06232b87
+  md5: 211c6057cedbd4484f602f33e03b893e
+  depends:
+  - python
+  - __osx >=11.0
+  - python 3.11.* *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 24446
+  timestamp: 1766684451003
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/setproctitle-1.3.7-py312hb3ab3e3_0.conda
+  sha256: dd45d3ed8d50e0a7883e9503d8442ff91365e1e66c9e3a185ffe60a8e4516537
+  md5: 33cfb02eb9324f412e503419520f9fcb
+  depends:
+  - python
+  - python 3.12.* *_cpython
+  - __osx >=11.0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 24321
+  timestamp: 1766684468807
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/setproctitle-1.3.7-py313h6688731_0.conda
+  sha256: d60e7477e43fd1f60fcf1b9e8381493e8d6f486607c442d486d7416beb370dc4
+  md5: 3a065a5904e74955d58166a33f52c4a1
+  depends:
+  - python
+  - __osx >=11.0
+  - python 3.13.* *_cp313
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 24358
+  timestamp: 1766684446206
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/setproctitle-1.3.7-py314ha14b1ff_0.conda
+  sha256: 76f5d57709141ebba6128912d9b5b5007d37484d7d2baf441c47be64673e629a
+  md5: 3ac7ab12bb48de8c9684a94ab2c78b34
+  depends:
+  - python
+  - python 3.14.* *_cp314
+  - __osx >=11.0
+  - python_abi 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 24666
+  timestamp: 1766684438889
+- conda: https://conda.anaconda.org/conda-forge/win-64/setproctitle-1.3.7-py310h1637853_0.conda
+  sha256: 858de5ed8675808081d85bffd725df8a2a753e9aeffa99d625821345831f40af
+  md5: 577c16e6125cef95a2eb989cd9051003
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 20316
+  timestamp: 1766684462922
+- conda: https://conda.anaconda.org/conda-forge/win-64/setproctitle-1.3.7-py311hf893f09_0.conda
+  sha256: a2755b6bc8fc3600042db75c3c958ca0346fc5ac7b64e5d0b3ed524ac10d7c95
+  md5: 0e8ea84cebe19bb782d3804250b856a1
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 20645
+  timestamp: 1766684463149
+- conda: https://conda.anaconda.org/conda-forge/win-64/setproctitle-1.3.7-py312he5662c2_0.conda
+  sha256: 3dd469892d73933c3e5f28cee9767e966909031f2d9f7b076faca3ae9cfdfd15
+  md5: 33aedb12042c55dd66a17e77fb061d50
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 20586
+  timestamp: 1766684461382
+- conda: https://conda.anaconda.org/conda-forge/win-64/setproctitle-1.3.7-py313h5fd188c_0.conda
+  sha256: 572b465da620182304e292765f0d163569a7fa400165337b08ff9d8c316ce565
+  md5: f920906a4b8ae72e450e5f59eab48e21
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 20733
+  timestamp: 1766684466490
+- conda: https://conda.anaconda.org/conda-forge/win-64/setproctitle-1.3.7-py314hc5dbbe4_0.conda
+  sha256: 8f293ce82ae8974a6c8f9905e3de8bcc37baf20053fd53f14c91a3393302e88a
+  md5: 1c0042a95d57ff6a57a2c1f7ba72a7b2
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/setproctitle?source=hash-mapping
+  size: 20989
+  timestamp: 1766684462447
 - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
   sha256: e0778e4f276e9a81b51c56f51ec22a27b4d8fc955abc0be77ad09ca9bea06bb9
   md5: 8f28e299c11afdd79e0ec1e279dcdc52
@@ -17389,6 +18421,41 @@ packages:
   purls: []
   size: 200192
   timestamp: 1775657222120
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tcsh-6.24.16-h18c060e_0.conda
+  sha256: d1fbed202ac1a2292e2eed539c86c60f93d3382b89c867e51a406a0de16613fc
+  md5: 3caba8110333b5b05137e88b2eec15f9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libxcrypt >=4.4.36
+  - ncurses >=6.5,<7.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 386085
+  timestamp: 1752068404654
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tcsh-6.24.16-h7768305_0.conda
+  sha256: 77cc914f8c46439949f520e6386d9df5f3c7419bf3fe0c19b54ed2cd07b2717f
+  md5: 1a4cb84b92858150a1ecc6ffc7804b12
+  depends:
+  - __osx >=10.13
+  - libxcrypt >=4.4.36
+  - ncurses >=6.5,<7.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 366207
+  timestamp: 1752068493156
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tcsh-6.24.10-h92ec313_0.conda
+  sha256: 54a72e6b28d8703a157e3dbce9b6b2eed96eac4faf38ab3ef480eb4d3c827b9e
+  md5: bcf531539d8c790785ae53762bd3ca83
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 347410
+  timestamp: 1681632568927
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
   sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
   md5: cffd3bdd58090148f4cfcd831f4b26ab
@@ -18097,6 +19164,17 @@ packages:
   purls: []
   size: 19347
   timestamp: 1767320221943
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
+  sha256: e298b508b2473c4227206800dfb14c39e4b14fd79d4636132e9e1e4244cdf4aa
+  md5: c3197f8c0d5b955c904616b716aca093
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/wcwidth?source=hash-mapping
+  size: 71550
+  timestamp: 1770634638503
 - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
   sha256: 93807369ab91f230cf9e6e2a237eaa812492fe00face5b38068735858fba954f
   md5: 46e441ba871f524e2b067929da3051c2
@@ -18108,6 +19186,454 @@ packages:
   - pkg:pypi/win-inet-pton?source=hash-mapping
   size: 9555
   timestamp: 1733130678956
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xclip-0.13-hb9d3cd8_4.conda
+  sha256: 7795c9b28a643a7279e6008dfe625cda3c8ee8fa6e178d390d7e213fe4291a5d
+  md5: 60617f7654d84993ff0ccdfc55209b69
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxmu >=1.2.1,<2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 23536
+  timestamp: 1731320447881
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xonsh-0.19.10-py310hff52083_0.conda
+  sha256: d931f96fe3f5098c00a4900e128c700c540f3e2888bc9049afb94d9d8ea2d238
+  md5: eb5303c36b355dde29dae092bba9f3a5
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 1056738
+  timestamp: 1750799271101
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xonsh-0.23.1-py311h38be061_0.conda
+  sha256: 22e077c26f4e7f95ed90e367e7ffbd95092c5c2b41f0c0f0d9075e0020460f94
+  md5: acce80388cc42dfefa9aecc0cd6ad370
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 1505017
+  timestamp: 1776799883615
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xonsh-0.23.1-py312h7900ff3_0.conda
+  sha256: 486cc7c5e6880b08585b267804c5b56c6361cd7c08f6744704c37c099412e49a
+  md5: 196a153b71d249fb5ae4d77a93dc0abe
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 1477132
+  timestamp: 1776799861108
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xonsh-0.23.1-py313h78bf25f_0.conda
+  sha256: 75a1c9b7d7b50f9df122760538085b65932d207128407909d054d625c0949fbe
+  md5: 621c18a4a0dfd45147df9b06aa584860
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 1495400
+  timestamp: 1776799864750
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xonsh-0.23.1-py314hdafbbf9_0.conda
+  sha256: a1b362737364f7496a279a11133f943346df891885e3694402512ed043ac61d5
+  md5: 44088bd94d1ea7427b324a87dfa802c1
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=compressed-mapping
+  size: 2117240
+  timestamp: 1776799869014
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.19.10-py310h2ec42d9_0.conda
+  sha256: 332a4deb094d0af53f793a2da211a674228da8605a63c878c18063042d40c349
+  md5: bc8b4eacb8a60adc57e93b9be2424239
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 1056672
+  timestamp: 1750799511531
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py311h6eed73b_0.conda
+  sha256: d115f9b476d55b8ff131469b8c348435b8fd3371d40738cb91bb21a4379f0fec
+  md5: 29886df7a3c59b41ac11a8f3dd1b9e85
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 1508417
+  timestamp: 1776800396240
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py312hb401068_0.conda
+  sha256: 2352ae562f9c374cb337d70cbc9ac4bf4f6cf5813fe9813b3f91111fba429636
+  md5: 9a4d419e762d76f071cc415260196dd9
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 1473882
+  timestamp: 1776800096959
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py313habf4b1d_0.conda
+  sha256: a6ddffc946e490de8f5bd660a7dca4d29c0a6ee8b53bdce7adf573fc46db60da
+  md5: 44e78f3e870a14501da9c59b6968095e
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 1498500
+  timestamp: 1776800357842
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xonsh-0.23.1-py314hee6578b_0.conda
+  sha256: 5eecdf33e6fbc95b6ac870dd7e4ad3cd891bd567ebea917819b021e3812757dc
+  md5: c4e287ba0c03b76c88d74dab171899ed
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 2130427
+  timestamp: 1776800392174
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xonsh-0.19.10-py310hbe9552e_0.conda
+  sha256: f70817c023b5ffb4ec12d962ad67764ee0821b60cd92bee71074748cfbe2918f
+  md5: 978888a446efd298df4cdaa88dff201e
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 1059954
+  timestamp: 1750799650595
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xonsh-0.23.1-py311h267d04e_0.conda
+  sha256: a7017bf08d3f7024b15ae50f146385887f1f782e266b40969e9c4eb46b0e863a
+  md5: c52c9ce51f7f077f1773cc3ed30b3017
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 1508718
+  timestamp: 1776800490249
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xonsh-0.23.1-py312h81bd7bf_0.conda
+  sha256: eb4f7a20a24bf4786227ac79ece1ee1147ffffa03d56f129b03e33a639bc0df3
+  md5: b3c952334e694d5aefca77d80e3c1aa7
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 1476623
+  timestamp: 1776800191621
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xonsh-0.23.1-py313h8f79df9_0.conda
+  sha256: b7d6795e1bab918783de4fdd0d813cb86ae1f410ef06c20f1353f0220a033c4a
+  md5: 3ee458ea8ad670bf1e1437cb7303e719
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.13,<3.14.0a0
+  - python >=3.13,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 1497878
+  timestamp: 1776800644242
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xonsh-0.23.1-py314h4dc9dd8_0.conda
+  sha256: e944110b85df3ae96a0dc9e6f0c7bbc32b8e16d04853aa5eb3f1c3b9049a5fc3
+  md5: 4c3e69876c7569bd0b6165972569880f
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=compressed-mapping
+  size: 2083755
+  timestamp: 1776800251248
+- conda: https://conda.anaconda.org/conda-forge/win-64/xonsh-0.19.10-py310h5588dad_0.conda
+  sha256: 120f23c69404abf875b06774a56ba44923483f7a2603cb1d93a7e11487c6d154
+  md5: 4b330c012e904065427b0c5b72281b68
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 1164711
+  timestamp: 1750799565512
+- conda: https://conda.anaconda.org/conda-forge/win-64/xonsh-0.23.1-py311h1ea47a8_0.conda
+  sha256: 05a65995b4a659ab34ab1379bc79db0bfd10fde4343dd04c6f88a5e00351f41b
+  md5: b45b86659ce9e62af95bc830896f060f
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 1616457
+  timestamp: 1776800068748
+- conda: https://conda.anaconda.org/conda-forge/win-64/xonsh-0.23.1-py312h2e8e312_0.conda
+  sha256: e2a95feb62a3aa75aed1f7065b1cc6fa652cc73592100805b07e92e1c7c1f3e0
+  md5: 62846931ff97677092b8b22245aa303c
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 1588770
+  timestamp: 1776800045488
+- conda: https://conda.anaconda.org/conda-forge/win-64/xonsh-0.23.1-py313hfa70ccb_0.conda
+  sha256: 6e07b1be7c569460729453078c443c19b6b714c0514ac40e7b8aa549891f3da3
+  md5: 1a55642f981bfeb3485f845b76801030
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=hash-mapping
+  size: 1610046
+  timestamp: 1776800059005
+- conda: https://conda.anaconda.org/conda-forge/win-64/xonsh-0.23.1-py314h86ab7b2_0.conda
+  sha256: d6ee2d8bd9b5d925c7a8c1a32d539c370fbd4a4388caa2d34e1dcf6dfd1e7874
+  md5: 1819cca578cd16685c20325be8667962
+  depends:
+  - prompt_toolkit
+  - pygments >=2.2
+  - pyperclip
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  - setproctitle
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xonsh?source=compressed-mapping
+  size: 2258238
+  timestamp: 1776800046920
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+  sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
+  md5: fb901ff28063514abb6046c9ec2c4a45
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 58628
+  timestamp: 1734227592886
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+  sha256: 277841c43a39f738927145930ff963c5ce4c4dacf66637a3d95d802a64173250
+  md5: 1c74ff8c35dcadf952a16f752ca5aa49
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libuuid >=2.38.1,<3.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 27590
+  timestamp: 1741896361728
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+  sha256: 516d4060139dbb4de49a4dcdc6317a9353fb39ebd47789c14e6fe52de0deee42
+  md5: 861fb6ccbc677bb9a9fb2468430b9c6a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libxcb >=1.17.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 839652
+  timestamp: 1770819209719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+  sha256: 6bc6ab7a90a5d8ac94c7e300cc10beb0500eeba4b99822768ca2f2ef356f731b
+  md5: b2895afaf55bf96a8c8282a2e47a5de0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 15321
+  timestamp: 1762976464266
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+  sha256: 25d255fb2eef929d21ff660a0c687d38a6d2ccfbcbf0cc6aa738b12af6e9d142
+  md5: 1dafce8548e38671bea82e3f5c6ce22f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 20591
+  timestamp: 1762976546182
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+  sha256: 79c60fc6acfd3d713d6340d3b4e296836a0f8c51602327b32794625826bd052f
+  md5: 34e54f03dfea3e7a2dcf1453a85f1085
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 50326
+  timestamp: 1769445253162
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxmu-1.3.1-hb03c661_0.conda
+  sha256: 2feca3d789b6ad46bd40f71c135cc2f05cb17648a523ffa5f773a0add5bc21fe
+  md5: c68a1319c4e98c0504614f0abc6e8274
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - xorg-libxt >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 90301
+  timestamp: 1769675723651
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+  sha256: a8afba4a55b7b530eb5c8ad89737d60d60bc151a03fbef7a2182461256953f0e
+  md5: 279b0de5f6ba95457190a1c459a64e31
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 379686
+  timestamp: 1731860547604
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xsel-1.2.1-hb9d3cd8_6.conda
+  sha256: e13cab6260ccf8619547fea51b403301ea9ed0f667fa7e9e4f39c7d016d8caa4
+  md5: 16566b426488305d7fc8b084d5db94e9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 22715
+  timestamp: 1731322205283
 - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
   sha256: 6d9ea2f731e284e9316d95fa61869fe7bbba33df7929f82693c121022810f4ad
   md5: a77f85f77be52ff59391544bfe73390a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,15 @@ pytest-mock = "*"
 conda-build = "*"
 pre-commit = "*"
 
+# fish/tcsh/xonsh power the new-shell tests.  They are not packaged for
+# win-64 on conda-forge, so scope them to Unix targets only; Windows
+# runs simply skip those tests via shutil.which() guards.
 [tool.pixi.feature.test.target.linux-64.dependencies]
+fish = "*"
+tcsh = "*"
+xonsh = "*"
+
+[tool.pixi.feature.test.target.osx-64.dependencies]
 fish = "*"
 tcsh = "*"
 xonsh = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,19 +84,16 @@ pytest = "*"
 pytest-mock = "*"
 conda-build = "*"
 pre-commit = "*"
-xonsh = "*"
 
 [tool.pixi.feature.test.target.linux-64.dependencies]
 fish = "*"
 tcsh = "*"
-
-[tool.pixi.feature.test.target.osx-64.dependencies]
-fish = "*"
-tcsh = "*"
+xonsh = "*"
 
 [tool.pixi.feature.test.target.osx-arm64.dependencies]
 fish = "*"
 tcsh = "*"
+xonsh = "*"
 
 [tool.pixi.feature.py310.dependencies]
 python = "3.10.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,19 @@ pytest = "*"
 pytest-mock = "*"
 conda-build = "*"
 pre-commit = "*"
+xonsh = "*"
+
+[tool.pixi.feature.test.target.linux-64.dependencies]
+fish = "*"
+tcsh = "*"
+
+[tool.pixi.feature.test.target.osx-64.dependencies]
+fish = "*"
+tcsh = "*"
+
+[tool.pixi.feature.test.target.osx-arm64.dependencies]
+fish = "*"
+tcsh = "*"
 
 [tool.pixi.feature.py310.dependencies]
 python = "3.10.*"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,10 @@
+import pytest
+
+
 pytest_plugins = ("conda.testing.fixtures",)
+
+
+@pytest.fixture(scope="session")
+def simple_env(session_tmp_env):
+    with session_tmp_env() as prefix:
+        yield prefix

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -1,0 +1,192 @@
+import shutil
+import sys
+
+import pexpect
+import pytest
+
+from conda_spawn.contrib import (
+    CshShell,
+    FishShell,
+    TcshShell,
+    XonshShell,
+)
+
+
+@pytest.fixture
+def fish_shell(simple_env):
+    return FishShell(simple_env)
+
+
+@pytest.fixture
+def xonsh_shell(simple_env):
+    return XonshShell(simple_env)
+
+
+def _read_via_exit(proc, shell_name: str = "exit") -> str:
+    """Send `exit` and collect all output until EOF.
+
+    csh/tcsh/xonsh do not exit on a single `sendeof()`, so we send an explicit
+    `exit` command and then wait for the process to terminate.
+    """
+    proc.sendline("exit")
+    try:
+        proc.expect(pexpect.EOF, timeout=15)
+    except pexpect.TIMEOUT:
+        proc.terminate(force=True)
+    return (proc.before or b"").decode(errors="replace")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Pty's only available on Unix")
+@pytest.mark.skipif(shutil.which("fish") is None, reason="fish not installed")
+def test_fish_shell(simple_env):
+    shell = FishShell(simple_env)
+    proc = shell.spawn_tty()
+    proc.sendline("env")
+    proc.sendeof()
+    out = proc.read().decode(errors="replace")
+    assert "CONDA_SPAWN" in out
+    assert "CONDA_PREFIX" in out
+    assert str(simple_env) in out
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Pty's only available on Unix")
+@pytest.mark.skipif(shutil.which("fish") is None, reason="fish not installed")
+def test_fish_shell_ready_marker_synchronization(simple_env):
+    """Regression test: FishShell must use the ready-marker sync approach."""
+    shell = FishShell(simple_env)
+    proc = shell.spawn_tty()
+    try:
+        marker = FishShell.READY_MARKER
+        assert marker, "FishShell must define a non-empty READY_MARKER"
+        assert proc.after == marker.encode()
+    finally:
+        proc.sendeof()
+        proc.read()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Pty's only available on Unix")
+@pytest.mark.skipif(shutil.which("csh") is None, reason="csh not installed")
+def test_csh_shell(simple_env):
+    shell = CshShell(simple_env)
+    proc = shell.spawn_tty()
+    proc.sendline("env")
+    out = _read_via_exit(proc)
+    assert "CONDA_SPAWN" in out
+    assert "CONDA_PREFIX" in out
+    assert str(simple_env) in out
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Pty's only available on Unix")
+@pytest.mark.skipif(shutil.which("tcsh") is None, reason="tcsh not installed")
+def test_tcsh_shell(simple_env):
+    shell = TcshShell(simple_env)
+    proc = shell.spawn_tty()
+    proc.sendline("env")
+    out = _read_via_exit(proc)
+    assert "CONDA_SPAWN" in out
+    assert "CONDA_PREFIX" in out
+    assert str(simple_env) in out
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Pty's only available on Unix")
+@pytest.mark.skipif(shutil.which("xonsh") is None, reason="xonsh not installed")
+def test_xonsh_shell(simple_env):
+    shell = XonshShell(simple_env)
+    proc = shell.spawn_tty()
+    proc.sendline(
+        "import os; print('\\n'.join(f'{k}={v}' for k,v in __xonsh__.env.items()"
+        " if k.startswith('CONDA_')))"
+    )
+    out = _read_via_exit(proc)
+    assert "CONDA_SPAWN" in out
+    assert "CONDA_PREFIX" in out
+    assert str(simple_env) in out
+
+
+@pytest.mark.parametrize(
+    "cls, expected",
+    [
+        (FishShell, "fish"),
+        (CshShell, "csh"),
+        (TcshShell, "tcsh"),
+        (XonshShell, "xonsh"),
+    ],
+    ids=lambda x: x.__name__ if isinstance(x, type) else x,
+)
+def test_shell_executable(cls, expected, simple_env):
+    assert cls(simple_env).executable() == expected
+
+
+def test_fish_shell_prompt_preserves_existing_prompt(fish_shell):
+    prompt = fish_shell.prompt()
+    # Copies any existing fish_prompt to a namespaced backup ...
+    assert "__conda_spawn_orig_fish_prompt" in prompt
+    # ... and prepends CONDA_PROMPT_MODIFIER to the new fish_prompt.
+    assert '"$CONDA_PROMPT_MODIFIER"' in prompt
+
+
+def test_fish_shell_source_command_and_suffix(fish_shell):
+    assert fish_shell.source_command("/tmp/x.fish") == 'source "/tmp/x.fish"'
+    assert fish_shell.script_suffix == ".fish"
+
+
+@pytest.mark.parametrize("cls", [CshShell, TcshShell], ids=lambda c: c.__name__)
+def test_csh_family_prompt_guards_undefined_prompt(cls, simple_env):
+    """Regression test: csh raises 'Undefined variable' without this guard."""
+    prompt = cls(simple_env).prompt()
+    assert 'if (! $?prompt) set prompt = ""' in prompt
+    assert "set prompt=" in prompt
+    # The guard must come before the assignment, otherwise the expansion
+    # in ${prompt} happens before $prompt has been initialised.
+    assert prompt.index("if (! $?prompt)") < prompt.index("set prompt=")
+
+
+@pytest.mark.parametrize("cls", [CshShell, TcshShell], ids=lambda c: c.__name__)
+def test_csh_family_ready_marker_uses_echo(cls, simple_env):
+    """csh has no printf builtin; echo -n is the portable alternative."""
+    assert cls(simple_env).ready_marker_command().startswith("echo -n ")
+
+
+def test_xonsh_shell_rewrites_del_var(xonsh_shell):
+    """Regression test: bare `del $VAR` raises KeyError on fresh shells.
+
+    The XonshShell.script() override must replace every such line with the
+    safe `${...}.pop("VAR", None)` form.
+    """
+    script = xonsh_shell.script()
+    assert "del $" not in script
+    # The activator always emits these unset lines; each should be
+    # rewritten.  Checking one representative confirms the regex works.
+    assert '${...}.pop("CONDA_EXE", None)' in script
+
+
+def test_xonsh_shell_script_suffix_is_xsh(xonsh_shell):
+    """The activator reports .sh but xonsh needs .xsh for correct parsing."""
+    assert xonsh_shell.script_suffix == ".xsh"
+
+
+def test_xonsh_shell_post_activation_uses_subproc_form(xonsh_shell):
+    """Bare `stty echo` is ambiguous in xonsh; `$[...]` forces subproc."""
+    assert xonsh_shell.post_activation_command() == "$[stty echo]"
+
+
+def test_xonsh_shell_ready_marker_uses_print(xonsh_shell):
+    cmd = xonsh_shell.ready_marker_command()
+    assert cmd.startswith("print(")
+    assert "flush=True" in cmd
+    assert "end=" in cmd
+
+
+@pytest.mark.parametrize(
+    "cls, expected_markers",
+    [
+        (CshShell, ("set prompt=",)),
+        (TcshShell, ("set prompt=",)),
+        (FishShell, ()),
+        (XonshShell, ()),
+    ],
+    ids=lambda x: x.__name__ if isinstance(x, type) else repr(x),
+)
+def test_prompt_strip_markers(cls, expected_markers):
+    """Each subclass must declare the activator lines it wants stripped."""
+    assert cls.prompt_strip_markers == expected_markers

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,86 @@
+import sys
+
+import pytest
+import shellingham
+
+from conda_spawn.contrib import (
+    CshShell,
+    FishShell,
+    TcshShell,
+    XonshShell,
+)
+from conda_spawn.registry import (
+    SHELLS,
+    default_shell_class,
+    detect_shell_class,
+)
+from conda_spawn.shell import (
+    BashShell,
+    CmdExeShell,
+    PosixShell,
+    ZshShell,
+)
+
+
+def test_default_shell_class():
+    expected = CmdExeShell if sys.platform == "win32" else PosixShell
+    assert default_shell_class() is expected
+
+
+def test_detect_shell_class_fallback_on_failure(monkeypatch):
+    """If shellingham fails, detect_shell_class falls back to the default."""
+
+    def _raise(*args, **kwargs):
+        raise shellingham.ShellDetectionFailure("no shell")
+
+    monkeypatch.setattr(shellingham, "detect_shell", _raise)
+    assert detect_shell_class() is default_shell_class()
+
+
+def test_detect_shell_class_unknown_returns_default(monkeypatch):
+    """Unknown shell names fall back to the default class with a warning."""
+    monkeypatch.setattr(shellingham, "detect_shell", lambda: ("not-a-real-shell", "/x"))
+    assert detect_shell_class() is default_shell_class()
+
+
+@pytest.mark.parametrize(
+    "shell_name, expected_cls",
+    [
+        ("bash", BashShell),
+        ("zsh", ZshShell),
+        ("fish", FishShell),
+        ("csh", CshShell),
+        ("tcsh", TcshShell),
+        ("xonsh", XonshShell),
+    ],
+)
+def test_detect_shell_class_known(monkeypatch, shell_name, expected_cls):
+    monkeypatch.setattr(
+        shellingham,
+        "detect_shell",
+        lambda: (shell_name, f"/bin/{shell_name}"),
+    )
+    assert detect_shell_class() is expected_cls
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "ash",
+        "bash",
+        "cmd",
+        "cmd.exe",
+        "csh",
+        "dash",
+        "fish",
+        "posix",
+        "powershell",
+        "pwsh",
+        "tcsh",
+        "xonsh",
+        "zsh",
+    ],
+)
+def test_shells_registry_covers_supported_name(name):
+    """The SHELLS dispatch table must include every shell we claim to support."""
+    assert name in SHELLS

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -61,14 +61,14 @@ def test_posix_shell(simple_env):
 def test_posix_shell_ready_marker_synchronization(simple_env, request):
     """Regression test for the double-prompt fix (#22).
 
-    ``spawn_tty()`` prints a distinctive ready marker after the activation
-    script, the new ``PS1``, and ``stty echo`` have all been applied, and
-    then blocks on ``expect_exact`` until it sees that marker.  Because
-    ``expect_exact`` consumes everything up to *and including* the match,
+    `spawn_tty()` prints a distinctive ready marker after the activation
+    script, the new `PS1`, and `stty echo` have all been applied, and
+    then blocks on `expect_exact` until it sees that marker.  Because
+    `expect_exact` consumes everything up to *and including* the match,
     any output the shell emitted before activation completed -- including
     an initial prompt rendered from the parent process's (stale)
-    ``CONDA_DEFAULT_ENV``, which is what prompt tools like starship would
-    read -- ends up in ``child.before`` and is never forwarded to the
+    `CONDA_DEFAULT_ENV`, which is what prompt tools like starship would
+    read -- ends up in `child.before` and is never forwarded to the
     interactive user.
 
     Refs conda-incubator/conda-workspaces#20.
@@ -122,7 +122,7 @@ def _read_via_exit(proc, shell_name: str = "exit") -> str:
     """Send 'exit' and collect all output until EOF.
 
     csh/tcsh/xonsh do not exit on a single sendeof(), so we send an explicit
-    ``exit`` command and then wait for the process to terminate.
+    `exit` command and then wait for the process to terminate.
     """
     proc.sendline("exit")
     try:
@@ -433,7 +433,7 @@ def test_xonsh_shell_rewrites_del_var(xonsh_shell):
     """Regression test: bare `del $VAR` raises KeyError on fresh shells.
 
     The XonshShell.script() override must replace every such line with the
-    safe ``${...}.pop("VAR", None)`` form.
+    safe `${...}.pop("VAR", None)` form.
     """
     script = xonsh_shell.script()
     assert "del $" not in script
@@ -448,7 +448,7 @@ def test_xonsh_shell_script_suffix_is_xsh(xonsh_shell):
 
 
 def test_xonsh_shell_post_activation_uses_subproc_form(xonsh_shell):
-    """Bare ``stty echo`` is ambiguous in xonsh; ``$[...]`` forces subproc."""
+    """Bare `stty echo` is ambiguous in xonsh; `$[...]` forces subproc."""
     assert xonsh_shell.post_activation_command() == "$[stty echo]"
 
 
@@ -476,7 +476,7 @@ def test_prompt_strip_markers(cls, expected_markers):
 
 
 def test_unix_shell_is_abstract_enough_to_require_subclass(simple_env):
-    """Instantiating UnixShell directly fails on the abstract ``Activator``.
+    """Instantiating UnixShell directly fails on the abstract `Activator`.
 
     UnixShell deliberately does not pick an Activator; it's the base class
     shared by PosixShell / FishShell / CshShell / XonshShell.

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -353,9 +353,7 @@ def test_detect_shell_class_fallback_on_failure(monkeypatch):
 
 def test_detect_shell_class_unknown_returns_default(monkeypatch):
     """Unknown shell names fall back to the default class with a warning."""
-    monkeypatch.setattr(
-        shellingham, "detect_shell", lambda: ("not-a-real-shell", "/x")
-    )
+    monkeypatch.setattr(shellingham, "detect_shell", lambda: ("not-a-real-shell", "/x"))
     assert detect_shell_class() is default_shell_class()
 
 

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -8,21 +8,24 @@ from subprocess import PIPE, check_output
 
 from conda.base.context import reset_context
 
-from conda_spawn import shell as shell_module
+from conda_spawn.contrib import (
+    CshShell,
+    FishShell,
+    TcshShell,
+    XonshShell,
+)
+from conda_spawn.registry import (
+    SHELLS,
+    default_shell_class,
+    detect_shell_class,
+)
 from conda_spawn.shell import (
     BashShell,
     CmdExeShell,
-    CshShell,
-    FishShell,
     PosixShell,
     PowershellShell,
-    SHELLS,
-    TcshShell,
     UnixShell,
-    XonshShell,
     ZshShell,
-    default_shell_class,
-    detect_shell_class,
 )
 
 
@@ -344,14 +347,14 @@ def test_detect_shell_class_fallback_on_failure(monkeypatch):
     def _raise(*args, **kwargs):
         raise shellingham.ShellDetectionFailure("no shell")
 
-    monkeypatch.setattr(shell_module.shellingham, "detect_shell", _raise)
+    monkeypatch.setattr(shellingham, "detect_shell", _raise)
     assert detect_shell_class() is default_shell_class()
 
 
 def test_detect_shell_class_unknown_returns_default(monkeypatch):
     """Unknown shell names fall back to the default class with a warning."""
     monkeypatch.setattr(
-        shell_module.shellingham, "detect_shell", lambda: ("not-a-real-shell", "/x")
+        shellingham, "detect_shell", lambda: ("not-a-real-shell", "/x")
     )
     assert detect_shell_class() is default_shell_class()
 
@@ -369,7 +372,7 @@ def test_detect_shell_class_unknown_returns_default(monkeypatch):
 )
 def test_detect_shell_class_known(monkeypatch, shell_name, expected_cls):
     monkeypatch.setattr(
-        shell_module.shellingham,
+        shellingham,
         "detect_shell",
         lambda: (shell_name, f"/bin/{shell_name}"),
     )

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,3 +1,4 @@
+import shutil
 import sys
 
 import pytest
@@ -5,7 +6,15 @@ from subprocess import PIPE, check_output
 
 from conda.base.context import reset_context
 
-from conda_spawn.shell import PosixShell, PowershellShell, CmdExeShell
+from conda_spawn.shell import (
+    CmdExeShell,
+    CshShell,
+    FishShell,
+    PosixShell,
+    PowershellShell,
+    TcshShell,
+    XonshShell,
+)
 
 
 @pytest.fixture(scope="session")
@@ -70,6 +79,89 @@ def test_posix_shell_ready_marker_synchronization(simple_env, request):
     # someone removes the marker sync this assertion fails loudly
     # instead of regressing to the old racy os.read()-based approach.
     assert proc.after == marker.encode()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Pty's only available on Unix")
+@pytest.mark.skipif(shutil.which("fish") is None, reason="fish not installed")
+def test_fish_shell(simple_env):
+    shell = FishShell(simple_env)
+    proc = shell.spawn_tty()
+    proc.sendline("env")
+    proc.sendeof()
+    out = proc.read().decode(errors="replace")
+    assert "CONDA_SPAWN" in out
+    assert "CONDA_PREFIX" in out
+    assert str(simple_env) in out
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Pty's only available on Unix")
+@pytest.mark.skipif(shutil.which("fish") is None, reason="fish not installed")
+def test_fish_shell_ready_marker_synchronization(simple_env):
+    """Regression test: FishShell must use the ready-marker sync approach."""
+    shell = FishShell(simple_env)
+    proc = shell.spawn_tty()
+    try:
+        marker = FishShell._READY_MARKER
+        assert marker, "FishShell must define a non-empty _READY_MARKER"
+        assert proc.after == marker.encode()
+    finally:
+        proc.sendeof()
+        proc.read()
+
+
+def _read_via_exit(proc, shell_name: str = "exit") -> str:
+    """Send 'exit' and collect all output until EOF.
+
+    csh/tcsh/xonsh do not exit on a single sendeof(), so we send an explicit
+    ``exit`` command and then wait for the process to terminate.
+    """
+    import pexpect
+
+    proc.sendline("exit")
+    try:
+        proc.expect(pexpect.EOF, timeout=15)
+    except pexpect.TIMEOUT:
+        proc.terminate(force=True)
+    return (proc.before or b"").decode(errors="replace")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Pty's only available on Unix")
+@pytest.mark.skipif(shutil.which("csh") is None, reason="csh not installed")
+def test_csh_shell(simple_env):
+    shell = CshShell(simple_env)
+    proc = shell.spawn_tty()
+    proc.sendline("env")
+    out = _read_via_exit(proc)
+    assert "CONDA_SPAWN" in out
+    assert "CONDA_PREFIX" in out
+    assert str(simple_env) in out
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Pty's only available on Unix")
+@pytest.mark.skipif(shutil.which("tcsh") is None, reason="tcsh not installed")
+def test_tcsh_shell(simple_env):
+    shell = TcshShell(simple_env)
+    proc = shell.spawn_tty()
+    proc.sendline("env")
+    out = _read_via_exit(proc)
+    assert "CONDA_SPAWN" in out
+    assert "CONDA_PREFIX" in out
+    assert str(simple_env) in out
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Pty's only available on Unix")
+@pytest.mark.skipif(shutil.which("xonsh") is None, reason="xonsh not installed")
+def test_xonsh_shell(simple_env):
+    shell = XonshShell(simple_env)
+    proc = shell.spawn_tty()
+    proc.sendline(
+        "import os; print('\\n'.join(f'{k}={v}' for k,v in __xonsh__.env.items()"
+        " if k.startswith('CONDA_')))"
+    )
+    out = _read_via_exit(proc)
+    assert "CONDA_SPAWN" in out
+    assert "CONDA_PREFIX" in out
+    assert str(simple_env) in out
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Powershell only tested on Windows")

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,11 +1,14 @@
 import shutil
 import sys
 
+import pexpect
 import pytest
+import shellingham
 from subprocess import PIPE, check_output
 
 from conda.base.context import reset_context
 
+from conda_spawn import shell as shell_module
 from conda_spawn.shell import (
     BashShell,
     CmdExeShell,
@@ -121,8 +124,6 @@ def _read_via_exit(proc, shell_name: str = "exit") -> str:
     csh/tcsh/xonsh do not exit on a single sendeof(), so we send an explicit
     ``exit`` command and then wait for the process to terminate.
     """
-    import pexpect
-
     proc.sendline("exit")
     try:
         proc.expect(pexpect.EOF, timeout=15)
@@ -306,19 +307,30 @@ def test_condabin_first_cmd(simple_env, conda_env, no_prompt):
         assert out.index(f"{sys.prefix}\\condabin\\conda") < out.index(str(conda_env))
 
 
-# ---------------------------------------------------------------------------
-# Unit tests that do not need a real PTY.  These exercise the script /
-# prompt generation directly and therefore run on every platform, covering
-# code paths that the TTY-based tests skip on Windows.
-# ---------------------------------------------------------------------------
+@pytest.fixture
+def fish_shell(simple_env):
+    return FishShell(simple_env)
 
 
-def test_bash_shell_executable(simple_env):
-    assert BashShell(simple_env).executable() == "bash"
+@pytest.fixture
+def xonsh_shell(simple_env):
+    return XonshShell(simple_env)
 
 
-def test_zsh_shell_executable(simple_env):
-    assert ZshShell(simple_env).executable() == "zsh"
+@pytest.mark.parametrize(
+    "cls, expected",
+    [
+        (BashShell, "bash"),
+        (ZshShell, "zsh"),
+        (FishShell, "fish"),
+        (CshShell, "csh"),
+        (TcshShell, "tcsh"),
+        (XonshShell, "xonsh"),
+    ],
+    ids=lambda x: x.__name__ if isinstance(x, type) else x,
+)
+def test_shell_executable(cls, expected, simple_env):
+    assert cls(simple_env).executable() == expected
 
 
 def test_default_shell_class():
@@ -328,9 +340,6 @@ def test_default_shell_class():
 
 def test_detect_shell_class_fallback_on_failure(monkeypatch):
     """If shellingham fails, detect_shell_class falls back to the default."""
-    import shellingham
-
-    from conda_spawn import shell as shell_module
 
     def _raise(*args, **kwargs):
         raise shellingham.ShellDetectionFailure("no shell")
@@ -341,26 +350,35 @@ def test_detect_shell_class_fallback_on_failure(monkeypatch):
 
 def test_detect_shell_class_unknown_returns_default(monkeypatch):
     """Unknown shell names fall back to the default class with a warning."""
-    from conda_spawn import shell as shell_module
-
     monkeypatch.setattr(
         shell_module.shellingham, "detect_shell", lambda: ("not-a-real-shell", "/x")
     )
     assert detect_shell_class() is default_shell_class()
 
 
-def test_detect_shell_class_known(monkeypatch):
-    from conda_spawn import shell as shell_module
-
+@pytest.mark.parametrize(
+    "shell_name, expected_cls",
+    [
+        ("bash", BashShell),
+        ("zsh", ZshShell),
+        ("fish", FishShell),
+        ("csh", CshShell),
+        ("tcsh", TcshShell),
+        ("xonsh", XonshShell),
+    ],
+)
+def test_detect_shell_class_known(monkeypatch, shell_name, expected_cls):
     monkeypatch.setattr(
-        shell_module.shellingham, "detect_shell", lambda: ("bash", "/bin/bash")
+        shell_module.shellingham,
+        "detect_shell",
+        lambda: (shell_name, f"/bin/{shell_name}"),
     )
-    assert detect_shell_class() is BashShell
+    assert detect_shell_class() is expected_cls
 
 
-def test_shells_registry_covers_all_supported_names():
-    """The SHELLS dispatch table must include every shell we claim to support."""
-    expected = {
+@pytest.mark.parametrize(
+    "name",
+    [
         "ash",
         "bash",
         "cmd",
@@ -374,27 +392,30 @@ def test_shells_registry_covers_all_supported_names():
         "tcsh",
         "xonsh",
         "zsh",
-    }
-    assert expected <= set(SHELLS)
+    ],
+)
+def test_shells_registry_covers_supported_name(name):
+    """The SHELLS dispatch table must include every shell we claim to support."""
+    assert name in SHELLS
 
 
-def test_fish_shell_prompt_preserves_existing_prompt(simple_env):
-    prompt = FishShell(simple_env).prompt()
+def test_fish_shell_prompt_preserves_existing_prompt(fish_shell):
+    prompt = fish_shell.prompt()
     # Copies any existing fish_prompt to a namespaced backup ...
     assert "__conda_spawn_orig_fish_prompt" in prompt
     # ... and prepends CONDA_PROMPT_MODIFIER to the new fish_prompt.
     assert '"$CONDA_PROMPT_MODIFIER"' in prompt
 
 
-def test_fish_shell_source_command_and_suffix(simple_env):
-    shell = FishShell(simple_env)
-    assert shell.source_command("/tmp/x.fish") == 'source "/tmp/x.fish"'
-    assert shell.script_suffix == ".fish"
+def test_fish_shell_source_command_and_suffix(fish_shell):
+    assert fish_shell.source_command("/tmp/x.fish") == 'source "/tmp/x.fish"'
+    assert fish_shell.script_suffix == ".fish"
 
 
-def test_csh_shell_prompt_guards_undefined_prompt(simple_env):
+@pytest.mark.parametrize("cls", [CshShell, TcshShell], ids=lambda c: c.__name__)
+def test_csh_family_prompt_guards_undefined_prompt(cls, simple_env):
     """Regression test: csh raises 'Undefined variable' without this guard."""
-    prompt = CshShell(simple_env).prompt()
+    prompt = cls(simple_env).prompt()
     assert 'if (! $?prompt) set prompt = ""' in prompt
     assert "set prompt=" in prompt
     # The guard must come before the assignment, otherwise the expansion
@@ -402,54 +423,56 @@ def test_csh_shell_prompt_guards_undefined_prompt(simple_env):
     assert prompt.index("if (! $?prompt)") < prompt.index("set prompt=")
 
 
-def test_csh_shell_ready_marker_uses_echo(simple_env):
+@pytest.mark.parametrize("cls", [CshShell, TcshShell], ids=lambda c: c.__name__)
+def test_csh_family_ready_marker_uses_echo(cls, simple_env):
     """csh has no printf builtin; echo -n is the portable alternative."""
-    assert CshShell(simple_env).ready_marker_command().startswith("echo -n ")
+    assert cls(simple_env).ready_marker_command().startswith("echo -n ")
 
 
-def test_tcsh_shell_inherits_csh_prompt(simple_env):
-    # TcshShell is a thin subclass of CshShell and must keep the guard.
-    assert 'if (! $?prompt) set prompt = ""' in TcshShell(simple_env).prompt()
-    assert TcshShell(simple_env).executable() == "tcsh"
-
-
-def test_xonsh_shell_rewrites_del_var(simple_env):
+def test_xonsh_shell_rewrites_del_var(xonsh_shell):
     """Regression test: bare `del $VAR` raises KeyError on fresh shells.
 
     The XonshShell.script() override must replace every such line with the
     safe ``${...}.pop("VAR", None)`` form.
     """
-    script = XonshShell(simple_env).script()
+    script = xonsh_shell.script()
     assert "del $" not in script
-    # The activator always emits these six unset lines; each should be
+    # The activator always emits these unset lines; each should be
     # rewritten.  Checking one representative confirms the regex works.
     assert '${...}.pop("CONDA_EXE", None)' in script
 
 
-def test_xonsh_shell_script_suffix_is_xsh(simple_env):
+def test_xonsh_shell_script_suffix_is_xsh(xonsh_shell):
     """The activator reports .sh but xonsh needs .xsh for correct parsing."""
-    assert XonshShell(simple_env).script_suffix == ".xsh"
+    assert xonsh_shell.script_suffix == ".xsh"
 
 
-def test_xonsh_shell_post_activation_uses_subproc_form(simple_env):
+def test_xonsh_shell_post_activation_uses_subproc_form(xonsh_shell):
     """Bare ``stty echo`` is ambiguous in xonsh; ``$[...]`` forces subproc."""
-    assert XonshShell(simple_env).post_activation_command() == "$[stty echo]"
+    assert xonsh_shell.post_activation_command() == "$[stty echo]"
 
 
-def test_xonsh_shell_ready_marker_uses_print(simple_env):
-    cmd = XonshShell(simple_env).ready_marker_command()
+def test_xonsh_shell_ready_marker_uses_print(xonsh_shell):
+    cmd = xonsh_shell.ready_marker_command()
     assert cmd.startswith("print(")
     assert "flush=True" in cmd
     assert "end=" in cmd
 
 
-def test_unix_shell_base_strips_prompt_markers(simple_env):
-    """PosixShell's ``prompt_strip_markers`` removes activator PS1 lines."""
-    assert PosixShell.prompt_strip_markers == ("PS1=",)
-    assert CshShell.prompt_strip_markers == ("set prompt=",)
-    # FishShell / XonshShell do not need stripping.
-    assert FishShell.prompt_strip_markers == ()
-    assert XonshShell.prompt_strip_markers == ()
+@pytest.mark.parametrize(
+    "cls, expected_markers",
+    [
+        (PosixShell, ("PS1=",)),
+        (CshShell, ("set prompt=",)),
+        (TcshShell, ("set prompt=",)),
+        (FishShell, ()),
+        (XonshShell, ()),
+    ],
+    ids=lambda x: x.__name__ if isinstance(x, type) else repr(x),
+)
+def test_prompt_strip_markers(cls, expected_markers):
+    """Each subclass must declare the activator lines it wants stripped."""
+    assert cls.prompt_strip_markers == expected_markers
 
 
 def test_unix_shell_is_abstract_enough_to_require_subclass(simple_env):

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -73,8 +73,8 @@ def test_posix_shell_ready_marker_synchronization(simple_env, request):
 
     request.addfinalizer(_drain)
 
-    marker = PosixShell._READY_MARKER
-    assert marker, "PosixShell must define a non-empty _READY_MARKER"
+    marker = PosixShell.READY_MARKER
+    assert marker, "PosixShell must define a non-empty READY_MARKER"
     # expect_exact() leaves the matched literal in child.after; if
     # someone removes the marker sync this assertion fails loudly
     # instead of regressing to the old racy os.read()-based approach.
@@ -101,8 +101,8 @@ def test_fish_shell_ready_marker_synchronization(simple_env):
     shell = FishShell(simple_env)
     proc = shell.spawn_tty()
     try:
-        marker = FishShell._READY_MARKER
-        assert marker, "FishShell must define a non-empty _READY_MARKER"
+        marker = FishShell.READY_MARKER
+        assert marker, "FishShell must define a non-empty READY_MARKER"
         assert proc.after == marker.encode()
     finally:
         proc.sendeof()

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -7,13 +7,19 @@ from subprocess import PIPE, check_output
 from conda.base.context import reset_context
 
 from conda_spawn.shell import (
+    BashShell,
     CmdExeShell,
     CshShell,
     FishShell,
     PosixShell,
     PowershellShell,
+    SHELLS,
     TcshShell,
+    UnixShell,
     XonshShell,
+    ZshShell,
+    default_shell_class,
+    detect_shell_class,
 )
 
 
@@ -298,3 +304,159 @@ def test_condabin_first_cmd(simple_env, conda_env, no_prompt):
         proc.kill()
         assert not proc.poll()
         assert out.index(f"{sys.prefix}\\condabin\\conda") < out.index(str(conda_env))
+
+
+# ---------------------------------------------------------------------------
+# Unit tests that do not need a real PTY.  These exercise the script /
+# prompt generation directly and therefore run on every platform, covering
+# code paths that the TTY-based tests skip on Windows.
+# ---------------------------------------------------------------------------
+
+
+def test_bash_shell_executable(simple_env):
+    assert BashShell(simple_env).executable() == "bash"
+
+
+def test_zsh_shell_executable(simple_env):
+    assert ZshShell(simple_env).executable() == "zsh"
+
+
+def test_default_shell_class():
+    expected = CmdExeShell if sys.platform == "win32" else PosixShell
+    assert default_shell_class() is expected
+
+
+def test_detect_shell_class_fallback_on_failure(monkeypatch):
+    """If shellingham fails, detect_shell_class falls back to the default."""
+    import shellingham
+
+    from conda_spawn import shell as shell_module
+
+    def _raise(*args, **kwargs):
+        raise shellingham.ShellDetectionFailure("no shell")
+
+    monkeypatch.setattr(shell_module.shellingham, "detect_shell", _raise)
+    assert detect_shell_class() is default_shell_class()
+
+
+def test_detect_shell_class_unknown_returns_default(monkeypatch):
+    """Unknown shell names fall back to the default class with a warning."""
+    from conda_spawn import shell as shell_module
+
+    monkeypatch.setattr(
+        shell_module.shellingham, "detect_shell", lambda: ("not-a-real-shell", "/x")
+    )
+    assert detect_shell_class() is default_shell_class()
+
+
+def test_detect_shell_class_known(monkeypatch):
+    from conda_spawn import shell as shell_module
+
+    monkeypatch.setattr(
+        shell_module.shellingham, "detect_shell", lambda: ("bash", "/bin/bash")
+    )
+    assert detect_shell_class() is BashShell
+
+
+def test_shells_registry_covers_all_supported_names():
+    """The SHELLS dispatch table must include every shell we claim to support."""
+    expected = {
+        "ash",
+        "bash",
+        "cmd",
+        "cmd.exe",
+        "csh",
+        "dash",
+        "fish",
+        "posix",
+        "powershell",
+        "pwsh",
+        "tcsh",
+        "xonsh",
+        "zsh",
+    }
+    assert expected <= set(SHELLS)
+
+
+def test_fish_shell_prompt_preserves_existing_prompt(simple_env):
+    prompt = FishShell(simple_env).prompt()
+    # Copies any existing fish_prompt to a namespaced backup ...
+    assert "__conda_spawn_orig_fish_prompt" in prompt
+    # ... and prepends CONDA_PROMPT_MODIFIER to the new fish_prompt.
+    assert '"$CONDA_PROMPT_MODIFIER"' in prompt
+
+
+def test_fish_shell_source_command_and_suffix(simple_env):
+    shell = FishShell(simple_env)
+    assert shell.source_command("/tmp/x.fish") == 'source "/tmp/x.fish"'
+    assert shell.script_suffix == ".fish"
+
+
+def test_csh_shell_prompt_guards_undefined_prompt(simple_env):
+    """Regression test: csh raises 'Undefined variable' without this guard."""
+    prompt = CshShell(simple_env).prompt()
+    assert 'if (! $?prompt) set prompt = ""' in prompt
+    assert "set prompt=" in prompt
+    # The guard must come before the assignment, otherwise the expansion
+    # in ${prompt} happens before $prompt has been initialised.
+    assert prompt.index("if (! $?prompt)") < prompt.index("set prompt=")
+
+
+def test_csh_shell_ready_marker_uses_echo(simple_env):
+    """csh has no printf builtin; echo -n is the portable alternative."""
+    assert CshShell(simple_env).ready_marker_command().startswith("echo -n ")
+
+
+def test_tcsh_shell_inherits_csh_prompt(simple_env):
+    # TcshShell is a thin subclass of CshShell and must keep the guard.
+    assert 'if (! $?prompt) set prompt = ""' in TcshShell(simple_env).prompt()
+    assert TcshShell(simple_env).executable() == "tcsh"
+
+
+def test_xonsh_shell_rewrites_del_var(simple_env):
+    """Regression test: bare `del $VAR` raises KeyError on fresh shells.
+
+    The XonshShell.script() override must replace every such line with the
+    safe ``${...}.pop("VAR", None)`` form.
+    """
+    script = XonshShell(simple_env).script()
+    assert "del $" not in script
+    # The activator always emits these six unset lines; each should be
+    # rewritten.  Checking one representative confirms the regex works.
+    assert '${...}.pop("CONDA_EXE", None)' in script
+
+
+def test_xonsh_shell_script_suffix_is_xsh(simple_env):
+    """The activator reports .sh but xonsh needs .xsh for correct parsing."""
+    assert XonshShell(simple_env).script_suffix == ".xsh"
+
+
+def test_xonsh_shell_post_activation_uses_subproc_form(simple_env):
+    """Bare ``stty echo`` is ambiguous in xonsh; ``$[...]`` forces subproc."""
+    assert XonshShell(simple_env).post_activation_command() == "$[stty echo]"
+
+
+def test_xonsh_shell_ready_marker_uses_print(simple_env):
+    cmd = XonshShell(simple_env).ready_marker_command()
+    assert cmd.startswith("print(")
+    assert "flush=True" in cmd
+    assert "end=" in cmd
+
+
+def test_unix_shell_base_strips_prompt_markers(simple_env):
+    """PosixShell's ``prompt_strip_markers`` removes activator PS1 lines."""
+    assert PosixShell.prompt_strip_markers == ("PS1=",)
+    assert CshShell.prompt_strip_markers == ("set prompt=",)
+    # FishShell / XonshShell do not need stripping.
+    assert FishShell.prompt_strip_markers == ()
+    assert XonshShell.prompt_strip_markers == ()
+
+
+def test_unix_shell_is_abstract_enough_to_require_subclass(simple_env):
+    """Instantiating UnixShell directly fails on the abstract ``Activator``.
+
+    UnixShell deliberately does not pick an Activator; it's the base class
+    shared by PosixShell / FishShell / CshShell / XonshShell.
+    """
+    with pytest.raises(AttributeError):
+        UnixShell(simple_env)

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,24 +1,10 @@
-import shutil
 import sys
 
-import pexpect
 import pytest
-import shellingham
 from subprocess import PIPE, check_output
 
 from conda.base.context import reset_context
 
-from conda_spawn.contrib import (
-    CshShell,
-    FishShell,
-    TcshShell,
-    XonshShell,
-)
-from conda_spawn.registry import (
-    SHELLS,
-    default_shell_class,
-    detect_shell_class,
-)
 from conda_spawn.shell import (
     BashShell,
     CmdExeShell,
@@ -27,12 +13,6 @@ from conda_spawn.shell import (
     UnixShell,
     ZshShell,
 )
-
-
-@pytest.fixture(scope="session")
-def simple_env(session_tmp_env):
-    with session_tmp_env() as prefix:
-        yield prefix
 
 
 @pytest.fixture(scope="session")
@@ -91,87 +71,6 @@ def test_posix_shell_ready_marker_synchronization(simple_env, request):
     # someone removes the marker sync this assertion fails loudly
     # instead of regressing to the old racy os.read()-based approach.
     assert proc.after == marker.encode()
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Pty's only available on Unix")
-@pytest.mark.skipif(shutil.which("fish") is None, reason="fish not installed")
-def test_fish_shell(simple_env):
-    shell = FishShell(simple_env)
-    proc = shell.spawn_tty()
-    proc.sendline("env")
-    proc.sendeof()
-    out = proc.read().decode(errors="replace")
-    assert "CONDA_SPAWN" in out
-    assert "CONDA_PREFIX" in out
-    assert str(simple_env) in out
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Pty's only available on Unix")
-@pytest.mark.skipif(shutil.which("fish") is None, reason="fish not installed")
-def test_fish_shell_ready_marker_synchronization(simple_env):
-    """Regression test: FishShell must use the ready-marker sync approach."""
-    shell = FishShell(simple_env)
-    proc = shell.spawn_tty()
-    try:
-        marker = FishShell.READY_MARKER
-        assert marker, "FishShell must define a non-empty READY_MARKER"
-        assert proc.after == marker.encode()
-    finally:
-        proc.sendeof()
-        proc.read()
-
-
-def _read_via_exit(proc, shell_name: str = "exit") -> str:
-    """Send 'exit' and collect all output until EOF.
-
-    csh/tcsh/xonsh do not exit on a single sendeof(), so we send an explicit
-    `exit` command and then wait for the process to terminate.
-    """
-    proc.sendline("exit")
-    try:
-        proc.expect(pexpect.EOF, timeout=15)
-    except pexpect.TIMEOUT:
-        proc.terminate(force=True)
-    return (proc.before or b"").decode(errors="replace")
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Pty's only available on Unix")
-@pytest.mark.skipif(shutil.which("csh") is None, reason="csh not installed")
-def test_csh_shell(simple_env):
-    shell = CshShell(simple_env)
-    proc = shell.spawn_tty()
-    proc.sendline("env")
-    out = _read_via_exit(proc)
-    assert "CONDA_SPAWN" in out
-    assert "CONDA_PREFIX" in out
-    assert str(simple_env) in out
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Pty's only available on Unix")
-@pytest.mark.skipif(shutil.which("tcsh") is None, reason="tcsh not installed")
-def test_tcsh_shell(simple_env):
-    shell = TcshShell(simple_env)
-    proc = shell.spawn_tty()
-    proc.sendline("env")
-    out = _read_via_exit(proc)
-    assert "CONDA_SPAWN" in out
-    assert "CONDA_PREFIX" in out
-    assert str(simple_env) in out
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Pty's only available on Unix")
-@pytest.mark.skipif(shutil.which("xonsh") is None, reason="xonsh not installed")
-def test_xonsh_shell(simple_env):
-    shell = XonshShell(simple_env)
-    proc = shell.spawn_tty()
-    proc.sendline(
-        "import os; print('\\n'.join(f'{k}={v}' for k,v in __xonsh__.env.items()"
-        " if k.startswith('CONDA_')))"
-    )
-    out = _read_via_exit(proc)
-    assert "CONDA_SPAWN" in out
-    assert "CONDA_PREFIX" in out
-    assert str(simple_env) in out
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Powershell only tested on Windows")
@@ -310,25 +209,11 @@ def test_condabin_first_cmd(simple_env, conda_env, no_prompt):
         assert out.index(f"{sys.prefix}\\condabin\\conda") < out.index(str(conda_env))
 
 
-@pytest.fixture
-def fish_shell(simple_env):
-    return FishShell(simple_env)
-
-
-@pytest.fixture
-def xonsh_shell(simple_env):
-    return XonshShell(simple_env)
-
-
 @pytest.mark.parametrize(
     "cls, expected",
     [
         (BashShell, "bash"),
         (ZshShell, "zsh"),
-        (FishShell, "fish"),
-        (CshShell, "csh"),
-        (TcshShell, "tcsh"),
-        (XonshShell, "xonsh"),
     ],
     ids=lambda x: x.__name__ if isinstance(x, type) else x,
 )
@@ -336,138 +221,10 @@ def test_shell_executable(cls, expected, simple_env):
     assert cls(simple_env).executable() == expected
 
 
-def test_default_shell_class():
-    expected = CmdExeShell if sys.platform == "win32" else PosixShell
-    assert default_shell_class() is expected
-
-
-def test_detect_shell_class_fallback_on_failure(monkeypatch):
-    """If shellingham fails, detect_shell_class falls back to the default."""
-
-    def _raise(*args, **kwargs):
-        raise shellingham.ShellDetectionFailure("no shell")
-
-    monkeypatch.setattr(shellingham, "detect_shell", _raise)
-    assert detect_shell_class() is default_shell_class()
-
-
-def test_detect_shell_class_unknown_returns_default(monkeypatch):
-    """Unknown shell names fall back to the default class with a warning."""
-    monkeypatch.setattr(shellingham, "detect_shell", lambda: ("not-a-real-shell", "/x"))
-    assert detect_shell_class() is default_shell_class()
-
-
-@pytest.mark.parametrize(
-    "shell_name, expected_cls",
-    [
-        ("bash", BashShell),
-        ("zsh", ZshShell),
-        ("fish", FishShell),
-        ("csh", CshShell),
-        ("tcsh", TcshShell),
-        ("xonsh", XonshShell),
-    ],
-)
-def test_detect_shell_class_known(monkeypatch, shell_name, expected_cls):
-    monkeypatch.setattr(
-        shellingham,
-        "detect_shell",
-        lambda: (shell_name, f"/bin/{shell_name}"),
-    )
-    assert detect_shell_class() is expected_cls
-
-
-@pytest.mark.parametrize(
-    "name",
-    [
-        "ash",
-        "bash",
-        "cmd",
-        "cmd.exe",
-        "csh",
-        "dash",
-        "fish",
-        "posix",
-        "powershell",
-        "pwsh",
-        "tcsh",
-        "xonsh",
-        "zsh",
-    ],
-)
-def test_shells_registry_covers_supported_name(name):
-    """The SHELLS dispatch table must include every shell we claim to support."""
-    assert name in SHELLS
-
-
-def test_fish_shell_prompt_preserves_existing_prompt(fish_shell):
-    prompt = fish_shell.prompt()
-    # Copies any existing fish_prompt to a namespaced backup ...
-    assert "__conda_spawn_orig_fish_prompt" in prompt
-    # ... and prepends CONDA_PROMPT_MODIFIER to the new fish_prompt.
-    assert '"$CONDA_PROMPT_MODIFIER"' in prompt
-
-
-def test_fish_shell_source_command_and_suffix(fish_shell):
-    assert fish_shell.source_command("/tmp/x.fish") == 'source "/tmp/x.fish"'
-    assert fish_shell.script_suffix == ".fish"
-
-
-@pytest.mark.parametrize("cls", [CshShell, TcshShell], ids=lambda c: c.__name__)
-def test_csh_family_prompt_guards_undefined_prompt(cls, simple_env):
-    """Regression test: csh raises 'Undefined variable' without this guard."""
-    prompt = cls(simple_env).prompt()
-    assert 'if (! $?prompt) set prompt = ""' in prompt
-    assert "set prompt=" in prompt
-    # The guard must come before the assignment, otherwise the expansion
-    # in ${prompt} happens before $prompt has been initialised.
-    assert prompt.index("if (! $?prompt)") < prompt.index("set prompt=")
-
-
-@pytest.mark.parametrize("cls", [CshShell, TcshShell], ids=lambda c: c.__name__)
-def test_csh_family_ready_marker_uses_echo(cls, simple_env):
-    """csh has no printf builtin; echo -n is the portable alternative."""
-    assert cls(simple_env).ready_marker_command().startswith("echo -n ")
-
-
-def test_xonsh_shell_rewrites_del_var(xonsh_shell):
-    """Regression test: bare `del $VAR` raises KeyError on fresh shells.
-
-    The XonshShell.script() override must replace every such line with the
-    safe `${...}.pop("VAR", None)` form.
-    """
-    script = xonsh_shell.script()
-    assert "del $" not in script
-    # The activator always emits these unset lines; each should be
-    # rewritten.  Checking one representative confirms the regex works.
-    assert '${...}.pop("CONDA_EXE", None)' in script
-
-
-def test_xonsh_shell_script_suffix_is_xsh(xonsh_shell):
-    """The activator reports .sh but xonsh needs .xsh for correct parsing."""
-    assert xonsh_shell.script_suffix == ".xsh"
-
-
-def test_xonsh_shell_post_activation_uses_subproc_form(xonsh_shell):
-    """Bare `stty echo` is ambiguous in xonsh; `$[...]` forces subproc."""
-    assert xonsh_shell.post_activation_command() == "$[stty echo]"
-
-
-def test_xonsh_shell_ready_marker_uses_print(xonsh_shell):
-    cmd = xonsh_shell.ready_marker_command()
-    assert cmd.startswith("print(")
-    assert "flush=True" in cmd
-    assert "end=" in cmd
-
-
 @pytest.mark.parametrize(
     "cls, expected_markers",
     [
         (PosixShell, ("PS1=",)),
-        (CshShell, ("set prompt=",)),
-        (TcshShell, ("set prompt=",)),
-        (FishShell, ()),
-        (XonshShell, ()),
     ],
     ids=lambda x: x.__name__ if isinstance(x, type) else repr(x),
 )


### PR DESCRIPTION
## Summary

Fixes #21 — adds fish, csh/tcsh, and xonsh shell support to `conda spawn`.

### Shell support

- New `UnixTTYShell` factors out the pexpect TTY-spawn logic shared by all Unix shells.
- New `FishShell`, `CshShell`/`TcshShell`, `XonshShell` handle each shell's quirks (csh's missing `printf` builtin and `$prompt` guard, xonsh's `$[stty echo]` and `del $VAR` rewriting, fish's `fish_prompt` composition).
- Best-effort shells live in `conda_spawn.contrib`; the `SHELLS` registry sits in `conda_spawn.registry` to keep imports clean.

### Tests

- New `test_{fish,csh,tcsh,xonsh}_shell`, skipped on Windows and when the shell binary isn't on PATH.
- Test layout mirrors the modules: `test_shell.py`, `test_contrib.py`, `test_registry.py`.
- `fish` / `tcsh` / `xonsh` added to the pixi test feature.

### CI

`defaults` doesn't package fish/tcsh/xonsh, so the matrix drops the defaults channel and runs OS × Python only against conda-forge. Re-adding `defaults` coverage later is straightforward.