### PR TITLE
Skip PowerShell -NoExit when stdin is not a TTY

### DIFF
--- a/conda_spawn/shell.py
+++ b/conda_spawn/shell.py
@@ -225,7 +225,15 @@ class PowershellShell(Shell):
         return "powershell"
 
     def args(self) -> tuple[str, ...]:
-        return ("-NoLogo", "-NoExit", "-File")
+        # ``-NoExit`` keeps PowerShell at its prompt after the activation
+        # script finishes, which is the whole point of ``conda spawn`` for
+        # an interactive user.  Without a TTY on stdin (tests, pipelines)
+        # we want PowerShell to exit cleanly once the script is done so the
+        # caller's ``communicate()`` returns instead of relying on a stdin-
+        # EOF race that can blow past the test's timeout on slow runners.
+        if sys.stdin.isatty():
+            return ("-NoLogo", "-NoExit", "-File")
+        return ("-NoLogo", "-File")
 
     def env(self) -> dict[str, str]:
         env = os.environ.copy()


### PR DESCRIPTION
## Summary

`tests/test_shell.py::test_condabin_first_powershell` (and its `test_powershell` sibling) intermittently times out on the Windows CI matrix while the other 8 Windows rows pass. Reproduced on PR #22's runs (twice in a row on `windows-latest, py312, defaults`) and discussed [there](https://github.com/conda-incubator/conda-spawn/pull/22#issuecomment-4333787812).

### Root cause

`PowershellShell.args()` unconditionally returns `("-NoLogo", "-NoExit", "-File")`. `-NoExit` keeps PowerShell at its prompt after the activation script finishes. In the tests, `proc.communicate(timeout=5)` therefore depends on PowerShell noticing EOF on its inherited (non-TTY) stdin and exiting on its own. On slow Windows runners the cold-start + activation + EOF detection dance occasionally exceeds the 5 s budget and the job goes red.

### Fix

Keep `-NoExit` for real interactive use (a user typing `conda spawn` *should* land at a PWSH prompt), but drop it when `sys.stdin.isatty()` is false so non-interactive callers (tests, pipelines, automation) get a deterministic, prompt process exit.

```python
def args(self) -> tuple[str, ...]:
    if sys.stdin.isatty():
        return ("-NoLogo", "-NoExit", "-File")
    return ("-NoLogo", "-File")
```

This mirrors the existing `PosixShell` pattern, which only calls `child.interact()` when `sys.stdin.isatty()`.

## Test plan

- [x] All 9 runnable tests pass locally on macOS (`pytest tests/`); the 6 Windows-only ones skip as expected.
- [x] CI green across the full Windows matrix (the whole point of this PR).
- [ ] Production interactive `conda spawn` on Windows still drops the user at a PWSH prompt (unchanged behavior, since stdin is a TTY in that case).