### PR TITLE
Add CHANGELOG.md and seed the 0.1.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Prototype release.
 
-[Unreleased]: https://github.com/conda-incubator/conda-spawn/compare/0.1.0...HEAD
 [0.1.0]: https://github.com/conda-incubator/conda-spawn/compare/0.0.5...0.1.0
 [0.0.5]: https://github.com/conda-incubator/conda-spawn/compare/0.0.4...0.0.5
 [0.0.4]: https://github.com/conda-incubator/conda-spawn/compare/0.0.3...0.0.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
+
+> Check the [latest release](https://github.com/conda-incubator/conda-spawn/releases/latest) and click on the "XX commits to main since this release" link to see the full diff.
 
 ## [0.1.0] - 2026-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,87 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-04-28
+
+### Added
+
+- Best-effort support for `fish`, `csh`/`tcsh`, and `xonsh` shells
+  ([#21], [#28]).
+- New `conda_spawn.contrib` module for shell registration discovery and
+  `conda_spawn.registry` module for the in-process shell registry.
+- Public subclass extension hooks on `Shell`/`UnixShell` (the leading
+  underscores were dropped) so out-of-tree plugins can extend behaviour
+  without reaching into private API.
+- Non-PTY unit tests for `UnixShell` alongside the existing PTY-based
+  integration tests.
+- Dependabot configuration for GitHub Actions, pre-commit, and pip.
+
+### Changed
+
+- Renamed `UnixTTYShell` to `UnixShell`.
+- Modernized the supported Python versions to 3.10–3.14 and the matching
+  CI matrix.
+- CI now tests against `conda-forge` only; the `defaults` channel was
+  dropped from the matrix.
+- Tests were split to mirror the module layout (`shell` / `contrib` /
+  `registry`) and parameterized with shared fixtures.
+
+### Fixed
+
+- Double shell prompt when spawning a new shell ([#22]).
+- PowerShell `-NoExit` is now skipped when stdin is not a TTY ([#30]).
+- `$CONDA_ROOT/condabin` stays first in `PATH` when replacing a prefix.
+- Ready-marker synchronization is sourced from the activation script to
+  avoid PTY echo leaks.
+
+### Removed
+
+- `spawn -n` / `spawn -p` mentions left over in the documentation.
+
+## [0.0.5] - 2025-01-29
+
+- Removed `-n, --name` and `-p, --prefix` flags in favour of a positional
+  argument, mirroring `conda activate` ([#12]).
+
+## [0.0.4] - 2025-01-20
+
+- Prevent nested activation by default; opt in via `--replace` and
+  `--stack` ([#6]).
+
+## [0.0.3] - 2025-01-16
+
+- Avoid `conda` in the base env getting shadowed by other `conda`
+  executables on `PATH` ([#5]).
+
+## [0.0.2] - 2025-01-15
+
+- Added the `--hook` option ([#2]).
+- Added the initial documentation site ([#3]).
+
+## [0.0.1] - 2025-01-14
+
+- Prototype release.
+
+[Unreleased]: https://github.com/conda-incubator/conda-spawn/compare/0.1.0...HEAD
+[0.1.0]: https://github.com/conda-incubator/conda-spawn/compare/0.0.5...0.1.0
+[0.0.5]: https://github.com/conda-incubator/conda-spawn/compare/0.0.4...0.0.5
+[0.0.4]: https://github.com/conda-incubator/conda-spawn/compare/0.0.3...0.0.4
+[0.0.3]: https://github.com/conda-incubator/conda-spawn/compare/0.0.2...0.0.3
+[0.0.2]: https://github.com/conda-incubator/conda-spawn/compare/0.0.1...0.0.2
+[0.0.1]: https://github.com/conda-incubator/conda-spawn/releases/tag/0.0.1
+
+[#2]: https://github.com/conda-incubator/conda-spawn/pull/2
+[#3]: https://github.com/conda-incubator/conda-spawn/pull/3
+[#5]: https://github.com/conda-incubator/conda-spawn/pull/5
+[#6]: https://github.com/conda-incubator/conda-spawn/pull/6
+[#12]: https://github.com/conda-incubator/conda-spawn/pull/12
+[#21]: https://github.com/conda-incubator/conda-spawn/issues/21
+[#22]: https://github.com/conda-incubator/conda-spawn/pull/22
+[#28]: https://github.com/conda-incubator/conda-spawn/pull/28
+[#30]: https://github.com/conda-incubator/conda-spawn/pull/30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - 2026-04-28
+## [0.1.0] - 2026-04-29
 
 ### Added
 


### PR DESCRIPTION
## Summary

- Introduce a `CHANGELOG.md` at the repo root following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) so release notes can be reviewed alongside the diff instead of being authored ad-hoc in the GitHub Release UI.
- Backfill `0.0.1`–`0.0.5` from the existing GitHub Releases so the file is self-contained.
- Draft the upcoming `0.1.0` entry covering work merged since `0.0.5`:
  - **Added**: best-effort `fish`, `csh`/`tcsh`, and `xonsh` shell support (#21, #28); new `conda_spawn.contrib` and `conda_spawn.registry` modules; public subclass extension hooks; non-PTY unit tests; Dependabot config.
  - **Changed**: `UnixTTYShell` → `UnixShell`; Python 3.10–3.14 + matching CI matrix; CI runs on `conda-forge` only; tests split to mirror module layout.
  - **Fixed**: double shell prompt (#22); PowerShell `-NoExit` skipped when stdin is not a TTY (#30); `\$CONDA_ROOT/condabin` stays first in `PATH` when replacing a prefix; ready-marker sourced from activation script.
  - **Removed**: stale `spawn -n` / `spawn -p` mentions in docs.

## Notes for the release

- Update the `0.1.0` date if we don't tag today.
- Cutting the release: tag `0.1.0` and publish a GitHub Release; `pypi.yml` handles the upload via `release: published`.
- The `Unreleased` compare link only resolves once the `0.1.0` tag exists — harmless until then.

## Test plan

- [x] Skim the rendered `CHANGELOG.md` on the PR page and confirm all PR/issue links resolve.
- [x] Confirm the `0.1.0` entry covers everything you want to call out.