### PR TITLE
Fix PowerShell conda.bat shadowing conda.exe on Windows

### DIFF
--- a/conda_spawn/shell.py
+++ b/conda_spawn/shell.py
@@ -18,6 +18,9 @@ if sys.platform != "win32":
 
     import pexpect
 
+from conda.base.context import context
+from conda.common.compat import on_win
+
 from . import activate
 
 
@@ -270,7 +273,17 @@ class PowershellShell(Shell):
         return proc.wait()
 
     def script(self) -> str:
-        return self._activator.execute()
+        script = self._activator.execute()
+        # On Windows, conda.bat (in condabin) silently no-ops for
+        # activate/deactivate in PowerShell. Define a conda function
+        # that routes to conda.exe so main_mock_activate fires as
+        # intended ("Run 'conda init'..."). We bake in the path from
+        # context.conda_exe because export_metavars=False means
+        # $Env:CONDA_EXE is not set during spawn activation.
+        if on_win:
+            conda_exe = context.conda_exe_vars_dict["CONDA_EXE"]
+            script += f'\r\nfunction conda {{ & "{conda_exe}" @args }}'
+        return script
 
     def prompt(self) -> str:
         return (

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+from conda.common.compat import on_win
+
+from conda_spawn.shell import PowershellShell
+
+
+@pytest.mark.skipif(
+    not on_win, reason="PowerShell conda function only needed on Windows"
+)
+def test_powershell_script_defines_conda_function(simple_env):
+    """PowerShell script must define a conda function routing to conda.exe (#32).
+
+    Without this, conda.bat (in condabin) silently no-ops for
+    activate/deactivate in PowerShell. The function ensures conda.exe
+    (the Python entry point) handles the command so main_mock_activate
+    fires as intended.
+    """
+    from conda.base.context import context
+
+    conda_exe = context.conda_exe_vars_dict["CONDA_EXE"]
+    shell = PowershellShell(simple_env)
+    script = shell.script()
+    assert f'function conda {{ & "{conda_exe}" @args }}' in script
+
+
+@pytest.mark.skipif(on_win, reason="conda function should not be injected on Unix")
+def test_powershell_script_no_conda_function_on_unix(simple_env):
+    """On non-Windows platforms the conda function is not injected."""
+    shell = PowershellShell(simple_env)
+    script = shell.script()
+    assert "function conda" not in script

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -6,9 +6,6 @@ from conda.common.compat import on_win
 from conda_spawn.shell import PowershellShell
 
 
-@pytest.mark.skipif(
-    not on_win, reason="PowerShell conda function only needed on Windows"
-)
 def test_powershell_script_defines_conda_function(simple_env):
     """PowerShell script must define a conda function routing to conda.exe (#32).
 
@@ -22,12 +19,4 @@ def test_powershell_script_defines_conda_function(simple_env):
     conda_exe = context.conda_exe_vars_dict["CONDA_EXE"]
     shell = PowershellShell(simple_env)
     script = shell.script()
-    assert f'function conda {{ & "{conda_exe}" @args }}' in script
-
-
-@pytest.mark.skipif(on_win, reason="conda function should not be injected on Unix")
-def test_powershell_script_no_conda_function_on_unix(simple_env):
-    """On non-Windows platforms the conda function is not injected."""
-    shell = PowershellShell(simple_env)
-    script = shell.script()
-    assert "function conda" not in script
+    assert (f'function conda {{ & "{conda_exe}" @args }}' in script) == on_win

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import pytest
 from conda.common.compat import on_win
 
 from conda_spawn.shell import PowershellShell


### PR DESCRIPTION
## Summary

On Windows, `_ensure_root_condabin_is_first()` puts `condabin\conda.bat` ahead of `Scripts\conda.exe` on PATH. In PowerShell, this means `conda activate`/`deactivate` resolve to the `.bat` shim, which silently no-ops. The real Python entry point (`Scripts\conda.exe`) never fires `main_mock_activate` to tell the user to run `conda init`.

Instead of moving `Scripts\` ahead of `condabin\` on PATH (which would expose every base entry point), this defines a PowerShell `conda` function in the activation script that routes directly to `$Env:CONDA_EXE`. Now `conda activate` inside a spawn hits `main_mock_activate` and errors loudly, same UX as POSIX shells, without leaking other base binaries onto PATH.

Fixes #32.

## Test plan

- [x] Unit test verifies the `conda` function is present in `PowershellShell.script()` output
- [x] Existing test suite passes
- [x] `ruff check` and `ruff format --check` clean