### PR TITLE
Fix CondaSubcommand deprecation warning

### DIFF
--- a/conda_spawn/plugin.py
+++ b/conda_spawn/plugin.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 from conda import plugins
+from conda.plugins.types import CondaSubcommand
 
 from . import cli
 
 
 @plugins.hookimpl
 def conda_subcommands():
-    yield plugins.CondaSubcommand(
+    yield CondaSubcommand(
         name="spawn",
         summary="Activate conda environments in new shell processes.",
         action=cli.execute,


### PR DESCRIPTION
## Summary

- Import `CondaSubcommand` from `conda.plugins.types` instead of using the deprecated `plugins.CondaSubcommand` shorthand

The deprecated path triggers a `DeprecationWarning` on every invocation and will be removed in conda 26.9.