### PR TITLE
Add `shell` as an alias for `spawn`

### DIFF
--- a/conda_spawn/plugin.py
+++ b/conda_spawn/plugin.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from inspect import signature
+
 from conda import plugins
 from conda.plugins.types import CondaSubcommand
 
@@ -8,9 +10,17 @@ from . import cli
 
 @plugins.hookimpl
 def conda_subcommands():
-    yield CondaSubcommand(
-        name="spawn",
-        summary="Activate conda environments in new shell processes.",
-        action=cli.execute,
-        configure_parser=cli.configure_parser,
-    )
+    kwargs = {
+        "summary": "Activate conda environments in new shell processes.",
+        "action": cli.execute,
+        "configure_parser": cli.configure_parser,
+    }
+    if "aliases" in signature(CondaSubcommand).parameters:
+        yield CondaSubcommand(
+            name="spawn",
+            aliases=("shell",),
+            **kwargs,
+        )
+    else:
+        for name in ("spawn", "shell"):
+            yield CondaSubcommand(name=name, **kwargs)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,60 @@
 import sys
+from types import SimpleNamespace
 
+import pytest
 from conda import CondaError
 
+from conda_spawn import plugin
 
-def test_cli(monkeypatch, conda_cli):
+
+@pytest.mark.parametrize("command", ("spawn", "shell"))
+def test_cli(monkeypatch, conda_cli, command):
     monkeypatch.setattr(sys, "argv", ["conda", *sys.argv[1:]])
-    out, err, _ = conda_cli("spawn", "-h", raises=SystemExit)
+    out, err, _ = conda_cli(command, "-h", raises=SystemExit)
     assert not err
     assert "conda spawn" in out
+
+
+def test_native_alias_registration(monkeypatch):
+    def conda_subcommand(*, name, summary, action, configure_parser=None, aliases=()):
+        return SimpleNamespace(
+            name=name,
+            summary=summary,
+            action=action,
+            configure_parser=configure_parser,
+            aliases=aliases,
+        )
+
+    monkeypatch.setattr(plugin, "CondaSubcommand", conda_subcommand)
+
+    (command,) = plugin.conda_subcommands()
+
+    assert command.name == "spawn"
+    assert command.aliases == ("shell",)
+
+
+def test_legacy_alias_registration(monkeypatch):
+    def conda_subcommand(*, name, summary, action, configure_parser=None):
+        return SimpleNamespace(
+            name=name,
+            summary=summary,
+            action=action,
+            configure_parser=configure_parser,
+        )
+
+    monkeypatch.setattr(plugin, "CondaSubcommand", conda_subcommand)
+
+    commands = tuple(plugin.conda_subcommands())
+
+    assert tuple(command.name for command in commands) == ("spawn", "shell")
+    assert commands[0].action is commands[1].action
+    assert commands[0].configure_parser is commands[1].configure_parser
+
+
+def test_shell_alias(monkeypatch, conda_cli):
+    monkeypatch.delenv("CONDA_SPAWN", raising=False)
+    args = (sys.prefix, "--hook", "--shell", "posix")
+    assert conda_cli("shell", *args) == conda_cli("spawn", *args)
 
 
 def test_nesting_disallowed(monkeypatch, conda_cli):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ def test_cli(monkeypatch, conda_cli, command):
     assert "conda spawn" in out
 
 
-def test_native_alias_registration(monkeypatch):
+def test_alias_registration_with_aliases_parameter(monkeypatch):
     def conda_subcommand(*, name, summary, action, configure_parser=None, aliases=()):
         return SimpleNamespace(
             name=name,
@@ -33,7 +33,7 @@ def test_native_alias_registration(monkeypatch):
     assert command.aliases == ("shell",)
 
 
-def test_legacy_alias_registration(monkeypatch):
+def test_alias_registration_without_aliases_parameter(monkeypatch):
     def conda_subcommand(*, name, summary, action, configure_parser=None):
         return SimpleNamespace(
             name=name,


### PR DESCRIPTION
## Summary

- expose `conda shell` as an alias for `conda spawn`
- use native `CondaSubcommand.aliases` when available
- register `shell` as a second subcommand on older conda releases

Closes #58.
